### PR TITLE
test: 注文登録APIの必須項目エラーメッセージ確認テストを追加 (#53)

### DIFF
--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerIntegrationTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerIntegrationTest.java
@@ -173,7 +173,8 @@ class OrderControllerIntegrationTest extends AbstractPostgreSQLIntegrationTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("入力値が不正です。"))
                 .andExpect(jsonPath("$.validationErrors", hasSize(1)))
-                .andExpect(jsonPath("$.validationErrors[*].field", hasItem("orderedAt")));
+                .andExpect(jsonPath("$.validationErrors[*].field", hasItem("orderedAt")))
+                .andExpect(jsonPath("$.validationErrors[*].message", hasItem("注文日時は必須です。")));
         }
 
         /**


### PR DESCRIPTION
## 概要

注文登録APIの必須項目エラーメッセージ確認テストを追加

## Issue

#53

## 対応内容

- `src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerIntegrationTest.java` を修正
- `POST /api/orders` の必須項目不足テストに、`orderedAt` のメッセージが「注文日時は必須です。」であることの確認を追加

## 完了条件

作業担当者がチェック

- [x] `OrderControllerIntegrationTest.java` が修正されている
- [x] `POST /api/orders` で注文日時未設定時のレスポンスメッセージを検証している
- [x] `validationErrors` 内の `orderedAt` に対して「注文日時は必須です。」を確認している
- [x] テストが成功する

## 変更影響範囲

作業担当者がチェック

- [ ] なし
- [x] API
- [ ] DB
- [ ] ドキュメント
- [ ] 設定ファイル
- [ ] その他（詳細は備考に記載）

## 確認観点

レビュー担当者がチェック

- [x] `POST /api/orders` の必須項目不足テストにメッセージ確認が追加されているか
- [x] `validationErrors` 内の `field=orderedAt` に対して `message=注文日時は必須です。` を確認しているか
- [x] 既存のバリデーションエラー確認観点を壊していないか
- [x] テストが安定して成功するか

## 備考（任意）

- 対象 Issue は「注文登録APIの必須項目エラーメッセージ確認テストを追加」
- 対象ファイルは `src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerIntegrationTest.java`
- バリデーションメッセージは `ValidationMessages.properties` / `ValidationMessages_ja.properties` で管理する方針
