### PR TITLE
refactor: OrderServiceIntegrationTestのvarをOrderJpaEntityへ修正 (#55)

### DIFF
--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceIntegrationTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceIntegrationTest.java
@@ -125,7 +125,7 @@ class OrderServiceIntegrationTest extends AbstractPostgreSQLIntegrationTest {
      * @return 注文JPAエンティティ
      */
     private OrderJpaEntity reconstructOrderJpaEntity(final String orderCode, final String orderStatus) {
-        var order = new OrderJpaEntity();
+        OrderJpaEntity order = new OrderJpaEntity();
         order.setId(UUID.randomUUID());
         order.setOrderCode(orderCode);
         order.setOrderedAt(OffsetDateTime.now());


### PR DESCRIPTION
## 概要

OrderServiceIntegrationTestのvarをOrderJpaEntityへ修正

## Issue

#55

## 対応内容

- `src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceIntegrationTest.java` を修正
- `var` で宣言している対象を `OrderJpaEntity` へ変更

## 完了条件

作業担当者がチェック

- [x] `OrderServiceIntegrationTest.java` が修正されている
- [x] 対象の `var` が `OrderJpaEntity` に置き換えられている
- [x] テストコードの可読性が向上している
- [x] テストが成功する

## 変更影響範囲

作業担当者がチェック

- [ ] なし
- [ ] API
- [ ] DB
- [ ] ドキュメント
- [ ] 設定ファイル
- [x] その他（テストコードの型明示リファクタリング）

## 確認観点

レビュー担当者がチェック

- [x] `OrderServiceIntegrationTest.java` の対象箇所が `var` から `OrderJpaEntity` に変更されているか
- [x] 修正によってテストコードの意図が分かりやすくなっているか
- [x] 業務仕様の変更を含まないリファクタリングになっているか
- [x] テストが安定して成功するか

## 備考（任意）

- 対象 Issue は「OrderServiceIntegrationTestのvarをOrderJpaEntityへ修正」  
- 対象ファイルは `src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceIntegrationTest.java`
- 本対応はテストコードの型明示を目的としたリファクタリングであり、業務仕様の変更は含まない
