### PR TITLE
refactor: グローバル例外ハンドラのメッセージを定数クラスへ移動 (#57)

### DIFF
--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ApiErrorMessageConstants.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ApiErrorMessageConstants.java
@@ -1,0 +1,33 @@
+package jp.co.shimizutdev.phoneorderapi.presentation.exception;
+
+/**
+ * APIエラーメッセージ定数
+ */
+public final class ApiErrorMessageConstants {
+
+    /**
+     * 入力値不正メッセージ
+     */
+    public static final String VALIDATION_ERROR = "入力値が不正です。";
+
+    /**
+     * リクエストボディ形式不正メッセージ
+     */
+    public static final String INVALID_REQUEST_BODY = "リクエストボディの形式が不正です。";
+
+    /**
+     * リクエスト処理失敗メッセージ
+     */
+    public static final String REQUEST_FAILED = "リクエスト処理に失敗しました。";
+
+    /**
+     * サーバー内部エラーメッセージ
+     */
+    public static final String INTERNAL_SERVER_ERROR = "サーバー内部でエラーが発生しました。";
+
+    /**
+     * インスタンス化を防止する。
+     */
+    private ApiErrorMessageConstants() {
+    }
+}

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/GlobalExceptionHandler.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/GlobalExceptionHandler.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class GlobalExceptionHandler {
 
     /**
-     * バリデーションエラーを処理
+     * バリデーションエラーを処理する。
      *
      * @param ex      MethodArgumentNotValidException
      * @param request HTTPリクエスト
@@ -35,12 +35,12 @@ public class GlobalExceptionHandler {
         List<ValidationError> validationErrors = ex.getBindingResult()
             .getFieldErrors()
             .stream()
-            .map(this::toApiValidationError)
+            .map(this::toValidationError)
             .toList();
 
         ErrorResponse response = createErrorResponse(
             HttpStatus.BAD_REQUEST,
-            "入力値が不正です。",
+            ApiErrorMessageConstants.VALIDATION_ERROR,
             request,
             validationErrors
         );
@@ -49,7 +49,7 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * 制約違反エラーを処理
+     * 制約違反エラーを処理する。
      *
      * @param ex      ConstraintViolationException
      * @param request HTTPリクエスト
@@ -69,7 +69,7 @@ public class GlobalExceptionHandler {
 
         ErrorResponse response = createErrorResponse(
             HttpStatus.BAD_REQUEST,
-            "入力値が不正です。",
+            ApiErrorMessageConstants.VALIDATION_ERROR,
             request,
             validationErrors
         );
@@ -78,7 +78,7 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * IllegalArgumentExceptionを処理
+     * IllegalArgumentExceptionを処理する。
      *
      * @param ex      IllegalArgumentException
      * @param request HTTPリクエスト
@@ -100,7 +100,7 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * JSON解析エラーを処理
+     * JSON解析エラーを処理する。
      *
      * @param request HTTPリクエスト
      * @return APIエラーレスポンス
@@ -111,7 +111,7 @@ public class GlobalExceptionHandler {
 
         ErrorResponse response = createErrorResponse(
             HttpStatus.BAD_REQUEST,
-            "リクエストボディの形式が不正です。",
+            ApiErrorMessageConstants.INVALID_REQUEST_BODY,
             request,
             List.of()
         );
@@ -120,7 +120,7 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * レスポンスステータス例外を処理
+     * レスポンスステータス例外を処理する。
      *
      * @param ex      ResponseStatusException
      * @param request HTTPリクエスト
@@ -128,28 +128,35 @@ public class GlobalExceptionHandler {
      */
     @ExceptionHandler(ResponseStatusException.class)
     public ResponseEntity<ErrorResponse> handleResponseStatusException(
-        ResponseStatusException ex,
-        HttpServletRequest request) {
-        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
-        String message = ex.getReason() != null ? ex.getReason() : "リクエスト処理に失敗しました。";
+        final ResponseStatusException ex,
+        final HttpServletRequest request) {
 
-        ErrorResponse response = createErrorResponse(status, message, request, List.of());
+        HttpStatus status = HttpStatus.valueOf(ex.getStatusCode().value());
+        String message = ex.getReason() != null
+            ? ex.getReason()
+            : ApiErrorMessageConstants.REQUEST_FAILED;
+
+        ErrorResponse response = createErrorResponse(
+            status,
+            message,
+            request,
+            List.of()
+        );
+
         return ResponseEntity.status(status).body(response);
     }
 
     /**
-     * 想定外例外を処理
+     * 想定外例外を処理する。
      *
      * @param request HTTPリクエスト
      * @return APIエラーレスポンス
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(
-        final HttpServletRequest request) {
-
+    public ResponseEntity<ErrorResponse> handleException(final HttpServletRequest request) {
         ErrorResponse response = createErrorResponse(
             HttpStatus.INTERNAL_SERVER_ERROR,
-            "サーバー内部でエラーが発生しました。",
+            ApiErrorMessageConstants.INTERNAL_SERVER_ERROR,
             request,
             List.of()
         );
@@ -158,12 +165,12 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * 項目エラーをバリデーションエラーへ変換
+     * 項目エラーをバリデーションエラーへ変換する。
      *
      * @param fieldError 項目エラー
      * @return バリデーションエラー
      */
-    private ValidationError toApiValidationError(final FieldError fieldError) {
+    private ValidationError toValidationError(final FieldError fieldError) {
         return ValidationError.create(
             fieldError.getField(),
             fieldError.getDefaultMessage()
@@ -171,7 +178,7 @@ public class GlobalExceptionHandler {
     }
 
     /**
-     * エラーレスポンスを生成
+     * エラーレスポンスを生成する。
      *
      * @param status           HTTPステータス
      * @param message          メッセージ


### PR DESCRIPTION
## 概要

グローバル例外ハンドラのメッセージを定数クラスへ移動

## Issue

#57

## 対応内容

- `src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ApiErrorMessageConstants.java` を新規作成
- `src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/GlobalExceptionHandler.java` の固定メッセージを `ApiErrorMessageConstants` 参照へ変更

## 完了条件

作業担当者がチェック

- [x] `ApiErrorMessageConstants.java` が追加されている
- [x] `GlobalExceptionHandler.java` の固定メッセージが定数クラス参照へ変更されている
- [x] 例外レスポンスの文言が従来どおり返却される

## 変更影響範囲

作業担当者がチェック

- [ ] なし
- [x] API
- [ ] DB
- [ ] ドキュメント
- [ ] 設定ファイル
- [x] その他（メッセージ管理の整理リファクタリング）

## 確認観点

レビュー担当者がチェック

- [x] `ApiErrorMessageConstants.java` が追加されているか
- [x] `GlobalExceptionHandler.java` の固定メッセージが定数参照へ置き換えられているか
- [x] バリデーションエラー・リクエストボディ不正・想定外例外時の文言が従来どおり返却されるか
- [x] 業務仕様の変更を含まないリファクタリングになっているか

## 備考（任意）

- 対象 Issue は「グローバル例外ハンドラのメッセージを定数クラスへ移動」 citeturn671473view0
- 対象ファイル
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ApiErrorMessageConstants.java`
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/GlobalExceptionHandler.java`
- 本対応はメッセージ管理の整理を目的としたリファクタリングであり、業務仕様の変更は含まない
