### PR TITLE
refactor: List型変数名の型名を除去し複数形へ統一 (#63)

### DIFF
--- a/docs/09_development/implementation-naming-rules-revised.md
+++ b/docs/09_development/implementation-naming-rules-revised.md
@@ -39,13 +39,13 @@
 #### 一覧取得
 
 - 日本語: 一覧取得
-- 英語: `get + XxxList`
+- 英語: `get + 複数形`
 
 例
 
 ```text
-getOrderList
-getDeliveryList
+getOrders
+getDeliveries
 ```
 
 #### 1件取得
@@ -125,19 +125,19 @@ BaseAuditMapper
 
 ### Service
 
-現行実装では、application の Service も Controller と同様に `get + XxxList` を採用している。  
+現行実装では、application の Service も Controller と同様に `get + 複数形` を採用している。  
 そのため、application の Service は次の命名を採用する。
 
 #### 一覧取得
 
 - 日本語: 一覧取得
-- 英語: `get + XxxList`
+- 英語: `get + 複数形`
 
 例
 
 ```text
-getOrderList
-getDeliveryList
+getOrders
+getDeliveries
 ```
 
 #### 1件取得
@@ -328,7 +328,7 @@ JpaAuditConfig
 
 ```text
 @GetMapping("/orders")
-public List<OrderResponse> getOrderList() {
+public List<OrderResponse> getOrders() {
     // ...
 }
 
@@ -346,7 +346,7 @@ public OrderResponse createOrder(@RequestBody OrderRequest requestDto) {
 ### application の例
 
 ```text
-public List<Order> getOrderList() {
+public List<Order> getOrders() {
     // ...
 }
 
@@ -390,11 +390,11 @@ Javadoc は日本語で記載する。
 
 ```text
 /**
- * 注文リストを取得
+ * 注文一覧を取得
  *
- * @return 注文レスポンスリスト
+ * @return 注文レスポンス一覧
  */
-public List<OrderResponse> getOrderList() {
+public List<OrderResponse> getOrders() {
     // ...
 }
 
@@ -413,11 +413,11 @@ public OrderResponse getOrderByOrderCode(String orderCode) {
 
 ```text
 /**
- * 注文リストを取得する
+ * 注文一覧を取得する
  *
- * @return 注文リスト
+ * @return 注文一覧
  */
-public List<Order> getOrderList() {
+public List<Order> getOrders() {
     // ...
 }
 
@@ -466,7 +466,7 @@ public class OrderResponse {
 
 ## 注意事項
 
-- presentation / application は現行実装に合わせて `getOrderList` を採用している
+- presentation / application は現行実装に合わせて `getOrders` を採用している
 - domain の値オブジェクトは `of` を基本とする
 - domain Repository は interface とし、永続化の詳細は infrastructure に置く
 - infrastructure の DB Repository は Spring Data JPA の慣習に合わせて `find` / `save` / `delete` を使う
@@ -481,7 +481,7 @@ public class OrderResponse {
 ### presentation
 
 ```text
-getOrderList
+getOrders
 getOrderByOrderCode
 createOrder
 updateOrder
@@ -491,7 +491,7 @@ deleteOrder
 ### application
 
 ```text
-getOrderList
+getOrders
 getOrderByOrderCode
 createOrder
 updateOrder

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderService.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderService.java
@@ -31,11 +31,11 @@ public class OrderService {
     private final OrderCodeGenerator orderCodeGenerator;
 
     /**
-     * 注文リストを取得する
+     * 注文一覧を取得する
      *
-     * @return 注文リスト
+     * @return 注文一覧
      */
-    public List<Order> getOrderList() {
+    public List<Order> getOrders() {
         return orderRepository.findAll();
     }
 

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepository.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepository.java
@@ -9,9 +9,9 @@ import java.util.Optional;
 public interface OrderRepository {
 
     /**
-     * 注文リストを取得する
+     * 注文一覧を取得する
      *
-     * @return 注文リスト
+     * @return 注文一覧
      */
     List<Order> findAll();
 

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/repository/order/OrderRepositoryImpl.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/repository/order/OrderRepositoryImpl.java
@@ -33,9 +33,9 @@ public class OrderRepositoryImpl implements OrderRepository {
     private EntityManager entityManager;
 
     /**
-     * 注文リストを取得する
+     * 注文一覧を取得する
      *
-     * @return 注文リスト
+     * @return 注文一覧
      */
     @Override
     public List<Order> findAll() {

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ErrorResponse.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ErrorResponse.java
@@ -41,7 +41,7 @@ public class ErrorResponse {
     private final String path;
 
     /**
-     * バリデーションエラーリスト
+     * バリデーションエラー一覧
      */
     private final List<ValidationError> validationErrors;
 
@@ -53,7 +53,7 @@ public class ErrorResponse {
      * @param error            エラー種別
      * @param message          メッセージ
      * @param path             リクエストパス
-     * @param validationErrors バリデーションエラーリスト
+     * @param validationErrors バリデーションエラー一覧
      */
     private ErrorResponse(
         final OffsetDateTime timestamp,
@@ -78,7 +78,7 @@ public class ErrorResponse {
      * @param error            エラー種別
      * @param message          メッセージ
      * @param path             リクエストパス
-     * @param validationErrors バリデーションエラーリスト
+     * @param validationErrors バリデーションエラー一覧
      */
     public static ErrorResponse create(
         final OffsetDateTime timestamp,

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderController.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderController.java
@@ -24,13 +24,13 @@ public class OrderController {
     private final OrderService orderService;
 
     /**
-     * 注文リストを取得する
+     * 注文一覧を取得する
      *
-     * @return 注文レスポンスリスト
+     * @return 注文レスポンス一覧
      */
     @GetMapping("/orders")
-    public List<OrderResponse> getOrderList() {
-        return OrderMapper.toResponseList(orderService.getOrderList());
+    public List<OrderResponse> getOrders() {
+        return OrderMapper.toResponseList(orderService.getOrders());
     }
 
     /**

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderMapper.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderMapper.java
@@ -36,17 +36,17 @@ public class OrderMapper {
     }
 
     /**
-     * 注文リストを注文レスポンスリストへ変換する
+     * 注文一覧を注文レスポンス一覧へ変換する
      *
-     * @param orderList 注文リスト
-     * @return 注文レスポンスリスト
+     * @param orders 注文一覧
+     * @return 注文レスポンス一覧
      */
-    public static List<OrderResponse> toResponseList(final List<Order> orderList) {
-        if (orderList == null) {
+    public static List<OrderResponse> toResponseList(final List<Order> orders) {
+        if (orders == null) {
             return Collections.emptyList();
         }
 
-        return orderList.stream()
+        return orders.stream()
             .map(OrderMapper::toResponse)
             .filter(Objects::nonNull)
             .toList();

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceIntegrationTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceIntegrationTest.java
@@ -75,20 +75,20 @@ class OrderServiceIntegrationTest extends AbstractPostgreSQLIntegrationTest {
 
     /**
      * <pre>
-     * 注文リストを取得できること。
+     * 注文一覧を取得できること。
      *
      * Given 注文データが複数件保存されている
-     * When 注文リストを取得する
-     * Then 保存された注文リストが返る
+     * When 注文一覧を取得する
+     * Then 保存された注文一覧が返る
      * </pre>
      */
     @Test
-    @DisplayName("注文リストを取得できること")
+    @DisplayName("注文一覧を取得できること")
     void shouldListOrders() {
         orderJpaRepository.save(reconstructOrderJpaEntity("ORD000001", "001"));
         orderJpaRepository.save(reconstructOrderJpaEntity("ORD000002", "002"));
 
-        List<Order> actual = orderService.getOrderList();
+        List<Order> actual = orderService.getOrders();
 
         assertEquals(2, actual.size());
         assertTrue(actual.stream().anyMatch(order -> "ORD000001".equals(order.getOrderCode().getValue())));

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectIntegrationTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectIntegrationTest.java
@@ -56,10 +56,10 @@ class MethodLogAspectIntegrationTest extends AbstractPostgreSQLIntegrationTest {
             + "('22222222-2222-2222-2222-222222222222', 'ORD000002', now(), '002', 'system', 'system')"
     })
     void shouldLogMethodStartAndReturnType(final CapturedOutput output) {
-        orderService.getOrderList();
+        orderService.getOrders();
 
-        assertThat(output).contains("[method start] methodName: OrderService#getOrderList");
-        assertThat(output).contains("[method end] methodName: OrderService#getOrderList");
+        assertThat(output).contains("[method start] methodName: OrderService#getOrders");
+        assertThat(output).contains("[method end] methodName: OrderService#getOrders");
         assertThat(output).contains("[method end] return value: [List<Order>(size=2)]");
         assertThat(output).contains("\"orderCode\":{\"value\":\"ORD000001\"}");
         assertThat(output).contains("\"orderCode\":{\"value\":\"ORD000002\"}");

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerIntegrationTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerIntegrationTest.java
@@ -48,17 +48,17 @@ class OrderControllerIntegrationTest extends AbstractPostgreSQLIntegrationTest {
     class ListOrders {
         /**
          * <pre>
-         * 注文リストを取得できること。
+         * 注文一覧を取得できること。
          *
          * Given 注文データが複数件登録されている
-         * When 注文リスト取得APIを実行する
-         * Then 200 OK と注文リストが返る
+         * When 注文一覧取得APIを実行する
+         * Then 200 OK と注文一覧が返る
          * </pre>
          *
          * @throws Exception 例外
          */
         @Test
-        @DisplayName("注文リストを取得できること")
+        @DisplayName("注文一覧を取得できること")
         @Sql(statements = {
             "insert into orders (id, order_code, ordered_at, order_status, created_by, updated_by) values (gen_random_uuid(), 'ORD000001', now(), '001', 'system', 'system')",
             "insert into orders (id, order_code, ordered_at, order_status, created_by, updated_by) values (gen_random_uuid(), 'ORD000002', now(), '002', 'system', 'system')"


### PR DESCRIPTION
## 概要

List 型の変数名に含まれていた型名を除去し、複数形の命名へ統一。  
あわせて実装命名ルール文書を更新し、関連する実装 / テストコードを修正。

## Issue

#

## 対応内容

- 実装命名ルール文書を修正
  - `docs/09_development/implementation-naming-rules-revised.md`
- List 型変数名から型名を除去し、複数形へ修正
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderService.java`
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepository.java`
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/repository/order/OrderRepositoryImpl.java`
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ErrorResponse.java`
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderController.java`
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderMapper.java`
- 変数名変更に伴い関連テストを修正
  - `src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceIntegrationTest.java`
  - `src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectIntegrationTest.java`
  - `src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerIntegrationTest.java`

## 完了条件

作業担当者がチェック

- [x] List 型変数名から型名が除去されている
- [x] List 型変数名が複数形へ統一されている
- [x] 実装命名ルール文書が更新されている
- [x] 関連する実装 / テストが修正されている
- [x] ビルドと関連テストが成功する

## 変更影響範囲

作業担当者がチェック

- [ ] なし
- [x] API
- [ ] DB
- [x] ドキュメント
- [ ] 設定ファイル
- [x] その他（命名統一リファクタリング / テストコード修正）

## 確認観点

レビュー担当者がチェック

- [x] List 型変数名に `List` などの型名が残っていないか
- [x] 変数名が複数形で統一されているか
- [x] 実装命名ルール文書の記載内容が今回の修正方針と一致しているか
- [x] 関連テストが修正され、既存の振る舞いを壊していないか
- [x] 業務仕様の変更を含まないリファクタリングになっているか

## 備考（任意）

- 本対応は命名統一を目的としたリファクタリングであり、業務仕様の変更は含まない
- コレクション変数は型名ではなく意味を表す複数形で命名する方針
