### PR TITLE
refactor: RequestResponseLogFilter のリクエストログ項目名の表記ゆれを修正 (#67)

### DIFF
--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilter.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilter.java
@@ -107,7 +107,7 @@ public class RequestResponseLogFilter extends OncePerRequestFilter {
      * @param request HTTPリクエスト
      */
     private void logRequest(final ContentCachingRequestWrapper request) {
-        log.info("[request] hTTP method: {}", request.getMethod());
+        log.info("[request] http method: {}", request.getMethod());
         log.info("[request] request uri: {}", request.getRequestURI());
         log.info("[request] query string: {}", nullToEmpty(request.getQueryString()));
         log.info("[request] parameters: {}", getParameters(request));

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterIntegrationTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterIntegrationTest.java
@@ -53,7 +53,7 @@ class RequestResponseLogFilterIntegrationTest extends AbstractPostgreSQLIntegrat
                     """))
             .andExpect(status().isBadRequest());
 
-        assertThat(output).contains("[request] hTTP method: POST");
+        assertThat(output).contains("[request] http method: POST");
         assertThat(output).contains("[request] request uri: /api/v1/orders");
         assertThat(output).contains("Authorization=****");
         assertThat(output).contains("[request] body:");


### PR DESCRIPTION
## 概要

RequestResponseLogFilter のリクエストログ項目名の誤記を修正した。
`[request] hTTP method` を `[request] http method` に統一した。

## Issue

#67

## 対応内容

- RequestResponseLogFilter.java のログ出力文言を修正
- RequestResponseLogFilterIntegrationTest.java の期待値を修正
- リクエストログの表記が統一されるように対応

## 完了条件

作業担当者がチェック

- [x] `[request] http method` でログ出力される
- [x] RequestResponseLogFilterIntegrationTest が成功する

## 変更影響範囲

作業担当者がチェック

- [x] なし
- [ ] API
- [ ] DB
- [ ] ドキュメント
- [ ] 設定ファイル
- [ ] その他（詳細は備考に記載）

## 確認観点

レビュー担当者がチェック

- [x] リクエストログの項目名が `[request] http method` に統一されているか
- [x] RequestResponseLogFilterIntegrationTest の期待値修正が妥当か
- [x] ログの出力内容に意図しない変更が入っていないか

## 備考（任意）

影響範囲はログ文言と関連テストのみ。
Issue 番号は起票後に記載する。
