### PR TITLE
refactor: ErrorResponse.java と ValidationError.java をクラスから record に修正 (#69)

### DIFF
--- a/docs/09_development/implementation-naming-rules-revised.md
+++ b/docs/09_development/implementation-naming-rules-revised.md
@@ -100,12 +100,53 @@ deleteDelivery
 
 - Request クラスは `XxxRequest`
 - Response クラスは `XxxResponse`
+- Error Response は `ErrorResponse`
+- バリデーション明細は `ValidationError`
+- DTO suffix は付けず、役割が分かる名称を使用する
 
 例
 
 ```text
 OrderRequest
 OrderResponse
+ErrorResponse
+ValidationError
+```
+
+### DTO / Error Response の実装方針
+
+- presentation 層の API 入出力モデルは `record` を基本とする
+- 対象は `Request` / `Response` / `ErrorResponse` / `ValidationError` など HTTP の入出力を表すモデルとする
+- DTO は不変データとして扱い、状態変更を持たせない
+- DTO の生成はコンストラクタ呼び出しを基本とする
+- `static factory method` は前処理・null 補正・生成意図の明確化が必要な場合のみ使用する
+- 単に全項目をそのまま渡すだけの `of(...)` / `from(...)` は原則作成しない
+- Entity から DTO への変換は `Mapper` に集約する
+- JPA Entity は DTO と別ルールで扱い、本方針の対象外とする
+
+例
+
+```text
+public record OrderRequest(OffsetDateTime orderedAt) {
+}
+
+public record OrderResponse(
+        String orderCode,
+        OffsetDateTime orderedAt,
+        String orderStatus) {
+}
+
+public record ErrorResponse(
+        OffsetDateTime timestamp,
+        int status,
+        String error,
+        String message,
+        String path,
+        List<ValidationError> errors) {
+}
+
+public record ValidationError(String field, String message) {
+}
 ```
 
 ### Mapper
@@ -450,15 +491,31 @@ Optional<Order> findByOrderCode(OrderCode orderCode);
 /**
  * 注文リクエスト
  */
-public class OrderRequest {
-    // ...
+public record OrderRequest(OffsetDateTime orderedAt) {
 }
 
 /**
  * 注文レスポンス
  */
-public class OrderResponse {
-    // ...
+public record OrderResponse(String orderCode, OffsetDateTime orderedAt, String orderStatus) {
+}
+
+/**
+ * エラーレスポンス
+ */
+public record ErrorResponse(
+        OffsetDateTime timestamp,
+        int status,
+        String error,
+        String message,
+        String path,
+        List<ValidationError> errors) {
+}
+
+/**
+ * バリデーションエラー
+ */
+public record ValidationError(String field, String message) {
 }
 ```
 
@@ -468,6 +525,8 @@ public class OrderResponse {
 
 - presentation / application は現行実装に合わせて `getOrders` を採用している
 - domain の値オブジェクトは `of` を基本とする
+- presentation の DTO は `record` を基本とし、単純な `new` のラッパーだけの `static factory method` は作成しない
+- DTO に `static factory method` を持たせる場合は、null 補正・不変化・生成意図の明確化などの意味を持たせる
 - domain Repository は interface とし、永続化の詳細は infrastructure に置く
 - infrastructure の DB Repository は Spring Data JPA の慣習に合わせて `find` / `save` / `delete` を使う
 - 命名は役割に応じて統一し、クラス間で混在させない

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ErrorResponse.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ErrorResponse.java
@@ -1,99 +1,26 @@
 package jp.co.shimizutdev.phoneorderapi.presentation.exception;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-
 import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
  * エラーレスポンス
+ *
+ * @param timestamp        発生日時
+ * @param status           HTTPステータス
+ * @param error            エラー種別
+ * @param message          メッセージ
+ * @param path             リクエストパス
+ * @param validationErrors バリデーションエラー一覧
  */
-@Getter
-@ToString
-@EqualsAndHashCode
-public class ErrorResponse {
-
-    /**
-     * 発生日時
-     */
-    private final OffsetDateTime timestamp;
-
-    /**
-     * HTTPステータス
-     */
-    private final int status;
-
-    /**
-     * エラー種別
-     */
-    private final String error;
-
-    /**
-     * メッセージ
-     */
-    private final String message;
-
-    /**
-     * リクエストパス
-     */
-    private final String path;
-
-    /**
-     * バリデーションエラー一覧
-     */
-    private final List<ValidationError> validationErrors;
-
-    /**
-     * コンストラクタ
-     *
-     * @param timestamp        発生日時
-     * @param status           HTTPステータス
-     * @param error            エラー種別
-     * @param message          メッセージ
-     * @param path             リクエストパス
-     * @param validationErrors バリデーションエラー一覧
-     */
-    private ErrorResponse(
-        final OffsetDateTime timestamp,
-        final int status,
-        final String error,
-        final String message,
-        final String path,
-        final List<ValidationError> validationErrors) {
-        this.timestamp = timestamp;
-        this.status = status;
-        this.error = error;
-        this.message = message;
-        this.path = path;
-        this.validationErrors = validationErrors;
-    }
-
-    /**
-     * エラーレスポンスを生成する
-     *
-     * @param timestamp        発生日時
-     * @param status           HTTPステータス
-     * @param error            エラー種別
-     * @param message          メッセージ
-     * @param path             リクエストパス
-     * @param validationErrors バリデーションエラー一覧
-     */
-    public static ErrorResponse create(
-        final OffsetDateTime timestamp,
-        final int status,
-        final String error,
-        final String message,
-        final String path,
-        final List<ValidationError> validationErrors) {
-        return new ErrorResponse(
-            timestamp,
-            status,
-            error,
-            message,
-            path,
-            validationErrors
-        );
-    }
+public record ErrorResponse(
+    OffsetDateTime timestamp,
+    int status,
+    String error,
+    String message,
+    String path,
+    List<ValidationError> validationErrors
+) {
 }
+
+

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/GlobalExceptionHandler.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/GlobalExceptionHandler.java
@@ -62,7 +62,7 @@ public class GlobalExceptionHandler {
 
         List<ValidationError> validationErrors = ex.getConstraintViolations()
             .stream()
-            .map(violation -> ValidationError.create(
+            .map(violation -> new ValidationError(
                 violation.getPropertyPath().toString(),
                 violation.getMessage()))
             .toList();
@@ -171,7 +171,7 @@ public class GlobalExceptionHandler {
      * @return バリデーションエラー
      */
     private ValidationError toValidationError(final FieldError fieldError) {
-        return ValidationError.create(
+        return new ValidationError(
             fieldError.getField(),
             fieldError.getDefaultMessage()
         );
@@ -192,7 +192,7 @@ public class GlobalExceptionHandler {
         final HttpServletRequest request,
         final List<ValidationError> validationErrors) {
 
-        return ErrorResponse.create(
+        return new ErrorResponse(
             OffsetDateTime.now(),
             status.value(),
             status.name(),

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ValidationError.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ValidationError.java
@@ -1,48 +1,13 @@
 package jp.co.shimizutdev.phoneorderapi.presentation.exception;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-
 /**
  * バリデーションエラー
+ *
+ * @param field   項目
+ * @param message メッセージ
  */
-@Getter
-@ToString
-@EqualsAndHashCode
-public class ValidationError {
-
-    /**
-     * 項目名
-     */
-    private final String field;
-
-    /**
-     * メッセージ
-     */
-    private final String message;
-
-    /**
-     * コンストラクタ
-     *
-     * @param field   項目
-     * @param message メッセージ
-     */
-    private ValidationError(final String field, final String message) {
-        this.field = field;
-        this.message = message;
-    }
-
-    /**
-     * バリデーションエラーを生成する
-     *
-     * @param field   項目
-     * @param message メッセージ
-     */
-    public static ValidationError create(final String field, final String message) {
-        return new ValidationError(
-            field,
-            message
-        );
-    }
+public record ValidationError(
+    String field,
+    String message
+) {
 }


### PR DESCRIPTION
## 概要

ErrorResponse.java と ValidationError.java をクラスから record に修正しました。
あわせて、DTO は record を基本とする方針を開発ルールへ反映しました。

## Issue

#69

## 対応内容

- ErrorResponse.java をクラスから record に修正
- ValidationError.java をクラスから record に修正
- GlobalExceptionHandler.java を record 化に合わせて修正
- implementation-naming-rules-revised.md に DTO は record を基本とする方針を追記

## 完了条件

作業担当者がチェック

- [x] ErrorResponse.java が record 化されている
- [x] ValidationError.java が record 化されている
- [x] GlobalExceptionHandler.java が修正後も正常に動作する
- [x] 開発ルールに DTO の record 方針が反映されている

## 変更影響範囲

作業担当者がチェック

- [ ] なし
- [x] API
- [ ] DB
- [x] ドキュメント
- [ ] 設定ファイル
- [ ] その他（詳細は備考に記載）

## 確認観点

レビュー担当者がチェック

- [x] ErrorResponse / ValidationError の record 化により例外レスポンス生成に影響が出ていないか
- [x] GlobalExceptionHandler の修正内容が妥当か
- [x] 開発ルールの記載内容に矛盾がないか

## 備考（任意）

- JPA Entity は本対応の対象外です
- DTO は record を基本とし、static factory method は必要な場合のみ使用する方針です
