### PR TITLE
refactor: OrderController の 404 エラーメッセージを定数化 (#71)

### DIFF
--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ApiErrorMessageConstants.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/exception/ApiErrorMessageConstants.java
@@ -26,6 +26,11 @@ public final class ApiErrorMessageConstants {
     public static final String INTERNAL_SERVER_ERROR = "サーバー内部でエラーが発生しました。";
 
     /**
+     * 注文未検出メッセージ
+     */
+    public static final String ORDER_NOT_FOUND = "注文が見つかりません。";
+
+    /**
      * インスタンス化を防止する。
      */
     private ApiErrorMessageConstants() {

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderController.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderController.java
@@ -3,6 +3,7 @@ package jp.co.shimizutdev.phoneorderapi.presentation.order;
 import jakarta.validation.Valid;
 import jp.co.shimizutdev.phoneorderapi.application.order.OrderService;
 import jp.co.shimizutdev.phoneorderapi.domain.order.Order;
+import jp.co.shimizutdev.phoneorderapi.presentation.exception.ApiErrorMessageConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -42,7 +43,10 @@ public class OrderController {
     @GetMapping("/orders/order-code/{orderCode}")
     public OrderResponse getOrderByOrderCode(@PathVariable final String orderCode) {
         Order order = orderService.getOrderByOrderCode(orderCode)
-            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "注文が見つかりません。"));
+            .orElseThrow(() -> new ResponseStatusException(
+                HttpStatus.NOT_FOUND,
+                ApiErrorMessageConstants.ORDER_NOT_FOUND
+            ));
 
         return OrderMapper.toResponse(order);
     }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerIntegrationTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerIntegrationTest.java
@@ -113,7 +113,8 @@ class OrderControllerIntegrationTest extends AbstractPostgreSQLIntegrationTest {
         @DisplayName("注文コードに対応する注文が存在しない場合は404を返すこと")
         void shouldReturnNotFoundWhenOrderCodeDoesNotExist() throws Exception {
             mockMvc.perform(get("/api/v1/orders/order-code/{orderCode}", "ORD999999"))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("注文が見つかりません。"));
         }
     }
 


### PR DESCRIPTION
## 概要

OrderController の 404 エラーメッセージを定数化し、例外メッセージ管理を統一した。
Controller の直書きメッセージを共通定数へ集約した。

## Issue

#（Issue作成後に記載）

## 対応内容

- `ApiErrorMessageConstants.java` に OrderController の 404 用エラーメッセージ定数を追加
- `OrderController.java` の 404 エラーメッセージ直書きを定数参照へ変更
- `OrderControllerIntegrationTest.java` の期待値を修正し、変更内容に追従

## 完了条件

作業担当者がチェック

- [x] 404 エラーメッセージが定数で管理されている
- [x] OrderController の 404 レスポンスが正常に動作する
- [x] 主要パターンの動作確認が完了している

## 変更影響範囲

作業担当者がチェック

- [ ] なし
- [x] API
- [ ] DB
- [ ] ドキュメント
- [ ] 設定ファイル
- [x] その他（例外メッセージ管理）

## 確認観点

レビュー担当者がチェック

- [x] OrderController の 404 エラーメッセージが定数参照に統一されているか
- [x] 404 レスポンスのメッセージ内容が従来意図どおり返却されるか
- [x] 他の例外メッセージ管理方針と整合しているか

## 備考（任意）

PR 作成時点では Issue 番号未記載のため、Issue 作成後に追記する。
