### PR TITLE
refactor: application-local.properties の作成に伴い、ローカル実行用の DB / Docker 設定…

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,11 +1,11 @@
 services:
   postgres:
     image: postgres:16
-    container_name: phone-order-api-dev-db
+    container_name: phone-order-api-local-db
     environment:
-      POSTGRES_DB: phone_order_api_dev_db
-      POSTGRES_USER: dev
-      POSTGRES_PASSWORD: dev
+      POSTGRES_DB: phone_order_api_local_db
+      POSTGRES_USER: local
+      POSTGRES_PASSWORD: local
       TZ: Asia/Tokyo
     ports:
       - "5432:5432"

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,9 +1,9 @@
 # ========================
 # Datasource
 # ========================
-spring.datasource.url=jdbc:postgresql://localhost:5432/phone_order_api_dev_db
-spring.datasource.username=dev
-spring.datasource.password=dev
+spring.datasource.url=jdbc:postgresql://localhost:5432/phone_order_api_local_db
+spring.datasource.username=local
+spring.datasource.password=local
 spring.datasource.driver-class-name=org.postgresql.Driver
 # ========================
 # SQL


### PR DESCRIPTION
## 概要

application-local.properties の作成に伴い、ローカル実行用の DB / Docker 設定を local に統一する。

## 背景（任意）

application-local.properties を導入したことで、ローカル実行用のプロファイル名は local に統一された。
一方で、DB名・ユーザー名・パスワード・Docker コンテナ名に dev が残っていると、設定意図と実態がずれて分かりにくいため、ローカル実行用の設定名称を local にそろえる。

## 対応内容

- docker/docker-compose.yml のコンテナ名を local 向けの名称に修正
- docker/docker-compose.yml の DB 名 / ユーザー名 / パスワードを local に修正
- src/main/resources/application-local.properties の Datasource 設定を local に修正
- ローカル実行時に Docker と Spring Boot の接続先設定が一致することを確認

## 完了条件

作業担当者がチェック

- [x] docker/docker-compose.yml の local 向け設定と application-local.properties の Datasource 設定が一致している
- [x] Spring Boot を local プロファイルで起動した際にローカル DB へ接続できる
- [x] コードが main にマージされている

## 関連PR

#

## 備考（任意）

- 本対応はローカル実行用設定の名称統一が目的であり、アプリケーション仕様変更は含まない
- IntelliJ の実行/デバッグ構成では Spring Boot の「有効なプロファイル」に local を設定して利用する
