### PR TITLE
chore: GitHub ActionsでCIを追加 (#87)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
 
     container:
       image: debian:trixie-slim
+      options: --add-host=host.docker.internal:host-gateway
       volumes:
         - /var/run/docker.sock:/var/run/docker.sock
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test on Debian Trixie Slim
+    runs-on: ubuntu-latest
+
+    container:
+      image: debian:trixie-slim
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+
+    steps:
+      - name: Install required packages
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            ca-certificates \
+            curl \
+            git
+          rm -rf /var/lib/apt/lists/*
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Eclipse Temurin 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Make Maven wrapper executable
+        run: chmod +x mvnw
+
+      - name: Run tests
+        env:
+          TESTCONTAINERS_HOST_OVERRIDE: host.docker.internal
+        run: ./mvnw -B test


### PR DESCRIPTION
## 概要

GitHub Actions を使用して、Pull Request 作成時および main ブランチへの push 時に自動テストを実行する CI を追加します。

## Issue

#87

## 対応内容

- `.github/workflows/ci.yml` を追加
- `pull_request` 時に CI が実行されるように設定
- `main` ブランチへの push 時に CI が実行されるように設定
- `debian:trixie-slim` コンテナ上でテストを実行
- Java は Eclipse Temurin 21 を使用
- Maven Wrapper で `./mvnw -B test` を実行
- Testcontainers 用に Docker socket をマウント

## 完了条件

作業担当者がチェック

- [x] `.github/workflows/ci.yml` が追加されている
- [x] CI が Pull Request 作成・更新時に実行される設定になっている
- [x] CI が main ブランチへの push 時に実行される設定になっている
- [x] `debian:trixie-slim` 上でテストが実行される設定になっている
- [x] Eclipse Temurin 21 が使用されている
- [x] `./mvnw -B test` が CI 上で実行される設定になっている
- [x] Testcontainers を使用するテスト向けに Docker socket を利用できる設定になっている

## 変更影響範囲

作業担当者がチェック

- [ ] なし
- [ ] API
- [ ] DB
- [ ] ドキュメント
- [x] 設定ファイル
- [ ] その他

## 確認観点

レビュアー担当者がチェック

- [x] GitHub Actions の workflow 構文が妥当である
- [x] `debian:trixie-slim` コンテナ上で CI が実行される
- [x] Eclipse Temurin 21 がセットアップされる
- [x] Maven cache の利用に問題がない
- [x] Testcontainers が Docker を利用できる
- [x] `./mvnw -B test` が成功する

## 備考

GitHub-hosted runner は `ubuntu-latest` を使用し、job の各 step は `debian:trixie-slim` コンテナ内で実行します。

Testcontainers が Docker を利用できるように、`/var/run/docker.sock` をコンテナへマウントしています。