### PR TITLE
chore: GitHub Actionsの警告を解消する (#89)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,13 @@ jobs:
           rm -rf /var/lib/apt/lists/*
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+
+      - name: Prepare Maven cache directory
+        run: mkdir -p "$HOME/.m2/repository"
 
       - name: Set up Eclipse Temurin 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '21'
@@ -46,4 +49,4 @@ jobs:
       - name: Run tests
         env:
           TESTCONTAINERS_HOST_OVERRIDE: host.docker.internal
-        run: ./mvnw -B test
+        run: ./mvnw -B -Dmaven.repo.local="$HOME/.m2/repository" test


### PR DESCRIPTION
## 概要

GitHub Actions の CI 実行結果で表示されていた警告を解消します。

## Issue

#89

## 対応内容

- `actions/checkout@v4` を `actions/checkout@v5` に更新
- `actions/setup-java@v4` を `actions/setup-java@v5` に更新
- Maven cache 用に `$HOME/.m2/repository` を事前作成
- Maven 実行時に `maven.repo.local` を明示
- CI のテスト実行コマンドを Maven cache 設定に合わせて更新

## 完了条件

作業担当者がチェック

- [x] `actions/checkout@v5` が使用されている
- [x] `actions/setup-java@v5` が使用されている
- [x] Node.js 20 actions deprecated 警告の解消を目的とした設定になっている
- [x] Maven cache の Path Validation Error 警告の解消を目的とした設定になっている
- [x] GitHub Actions の CI が実行される設定になっている
- [x] `./mvnw -B test` 相当のテストが CI 上で実行される設定になっている

## 変更影響範囲

作業担当者がチェック

- [ ] なし
- [ ] API
- [ ] DB
- [ ] ドキュメント
- [x] 設定ファイル
- [ ] その他

## 確認観点

レビュアー担当者がチェック

- [x] `actions/checkout@v5` で checkout が成功する
- [x] `actions/setup-java@v5` で Eclipse Temurin 21 がセットアップされる
- [x] Maven cache の保存時に Path Validation Error が発生しない
- [x] Node.js 20 actions deprecated 警告が発生しない
- [x] Testcontainers を使用するテストが成功する
- [x] `./mvnw -B -Dmaven.repo.local="$HOME/.m2/repository" test` が CI 上で成功する

## 備考

対象ファイルは `.github/workflows/ci.yml` です。

CI の実行環境は GitHub-hosted runner の `ubuntu-latest` を使用し、job の各 step は `debian:trixie-slim` コンテナ内で実行します。