### PR TITLE
docs: APIリクエスト・レスポンス例に curl 実行例を追加し、400 エラーレスポンス例のメッセージを実装に合わせる (#103)

### DIFF
--- a/docs/05_api/examples.md
+++ b/docs/05_api/examples.md
@@ -102,7 +102,7 @@ API利用者、設計レビュー、実装時の理解を目的とする。
   "timestamp": "2026-04-07T10:15:30+09:00",
   "status": 400,
   "error": "BAD_REQUEST",
-  "message": "入力内容に誤りがあります。",
+  "message": "入力値が不正です。",
   "path": "/api/v1/orders",
   "validationErrors": [
     {
@@ -111,4 +111,36 @@ API利用者、設計レビュー、実装時の理解を目的とする。
     }
   ]
 }
+```
+
+---
+
+## 6. curl 実行例
+
+### 注文作成
+
+```bash
+curl -i -X POST http://localhost:8080/api/v1/orders \
+  -H "Content-Type: application/json" \
+  -d '{"orderedAt":"2026-04-07T10:15:30+09:00"}'
+```
+
+### 注文参照
+
+```bash
+curl -i http://localhost:8080/api/v1/orders/ORD000001
+```
+
+### 注文一覧取得
+
+```bash
+curl -i http://localhost:8080/api/v1/orders
+```
+
+### 入力値不正
+
+```bash
+curl -i -X POST http://localhost:8080/api/v1/orders \
+  -H "Content-Type: application/json" \
+  -d '{}'
 ```


### PR DESCRIPTION
## 概要

`docs/05_api/examples.md` の API 例を実装内容に合わせて更新し、主要 API の curl 実行例を追加しました。

## Issue

close #103

## 対応内容

- 400 レスポンス例の `message` を実装の `ApiErrorMessageConstants.VALIDATION_ERROR` に合わせて修正
  - 修正前: `入力内容に誤りがあります。`
  - 修正後: `入力値が不正です。`
- `docs/05_api/examples.md` に curl 実行例を追加
  - 注文作成
  - 注文参照
  - 注文一覧取得
  - 入力値不正

## 完了条件

実装担当者がチェック

- [x] 400 レスポンス例の `message` が実装と一致している
- [x] 主要 API の curl 実行例が記載されている
- [x] Markdown の構成が崩れていないことを確認している

## レビュー観点

レビュー担当者がチェック

- [x] 400 レスポンス例の文言が実装と一致していること
- [x] curl 実行例のエンドポイント、HTTP メソッド、リクエストボディが妥当であること
- [x] ドキュメントとして読みやすい位置・粒度で追記されていること

## 備考（任意）

ドキュメントのみの変更です。アプリケーションテストは実行していません。