### PR TITLE
refactor: presentation層の例外処理と注文API実装を簡潔化する (#111)

### DIFF
--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/codegen/SequentialOrderCodeGenerator.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/codegen/SequentialOrderCodeGenerator.java
@@ -56,8 +56,7 @@ public class SequentialOrderCodeGenerator implements OrderCodeGenerator {
         String numericPart = currentOrderCode.substring(ORDER_CODE_PREFIX.length());
 
         try {
-            int currentNumber = Integer.parseInt(numericPart);
-            return OrderCode.of(formatOrderCode(currentNumber + 1));
+            return OrderCode.of(formatOrderCode(Integer.parseInt(numericPart) + 1));
         } catch (NumberFormatException ex) {
             throw new IllegalStateException("注文コードの連番部が不正です。", ex);
         }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandler.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandler.java
@@ -19,6 +19,9 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
 
 /**
  * API例外ハンドラ
@@ -26,6 +29,9 @@ import java.util.List;
 @RestControllerAdvice
 public class ApiExceptionHandler {
 
+    /**
+     * ログ
+     */
     private static final Logger log = LoggerFactory.getLogger(ApiExceptionHandler.class);
 
     /**
@@ -41,17 +47,15 @@ public class ApiExceptionHandler {
         final MethodArgumentNotValidException ex,
         final HttpServletRequest request) {
 
-        List<ApiValidationError> validationErrors = ex.getBindingResult()
-            .getFieldErrors()
-            .stream()
-            .map(this::toValidationError)
-            .toList();
-
         return buildErrorResponse(
             HttpStatus.BAD_REQUEST,
             ApiErrorResponseMessages.VALIDATION_ERROR,
             request,
-            validationErrors
+            ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(this::toValidationError)
+                .toList()
         );
     }
 
@@ -68,16 +72,14 @@ public class ApiExceptionHandler {
         final ConstraintViolationException ex,
         final HttpServletRequest request) {
 
-        List<ApiValidationError> validationErrors = ex.getConstraintViolations()
-            .stream()
-            .map(this::toValidationError)
-            .toList();
-
         return buildErrorResponse(
             HttpStatus.BAD_REQUEST,
             ApiErrorResponseMessages.VALIDATION_ERROR,
             request,
-            validationErrors
+            ex.getConstraintViolations()
+                .stream()
+                .map(this::toValidationError)
+                .toList()
         );
     }
 
@@ -161,13 +163,9 @@ public class ApiExceptionHandler {
         final ResponseStatusException ex,
         final HttpServletRequest request) {
 
-        String message = ex.getReason() != null
-            ? ex.getReason()
-            : ApiErrorResponseMessages.REQUEST_FAILED;
-
         return buildErrorResponse(
             ex.getStatusCode(),
-            resolveMessage(message, ApiErrorResponseMessages.REQUEST_FAILED),
+            resolveMessage(ex.getReason(), ApiErrorResponseMessages.REQUEST_FAILED),
             request,
             List.of()
         );
@@ -229,17 +227,20 @@ public class ApiExceptionHandler {
      * @return 項目名
      */
     private String extractViolationField(final ConstraintViolation<?> violation) {
-        String field = null;
-
-        for (Path.Node node : violation.getPropertyPath()) {
-            if (node.getName() != null) {
-                field = node.getName();
-            }
-        }
-
-        return field != null ? field : violation.getPropertyPath().toString();
+        return StreamSupport.stream(violation.getPropertyPath().spliterator(), false)
+            .map(Path.Node::getName)
+            .filter(Objects::nonNull)
+            .reduce((first, second) -> second)
+            .orElse(violation.getPropertyPath().toString());
     }
 
+    /**
+     * メッセージが null または空白の場合に、デフォルトメッセージへ補完する。
+     *
+     * @param message        判定対象メッセージ
+     * @param defaultMessage デフォルトメッセージ
+     * @return メッセージ
+     */
     private String resolveMessage(final String message, final String defaultMessage) {
         return message != null && !message.isBlank()
             ? message
@@ -262,7 +263,12 @@ public class ApiExceptionHandler {
         final List<ApiValidationError> validationErrors) {
 
         return ResponseEntity.status(statusCode)
-            .body(createErrorResponse(statusCode, message, request, validationErrors));
+            .body(createErrorResponse(
+                statusCode,
+                message,
+                request,
+                validationErrors
+            ));
     }
 
     /**
@@ -297,9 +303,8 @@ public class ApiExceptionHandler {
      * @return エラーコード文字列
      */
     private String resolveErrorCode(final HttpStatusCode statusCode) {
-        HttpStatus resolvedStatus = HttpStatus.resolve(statusCode.value());
-        return resolvedStatus != null
-            ? resolvedStatus.name()
-            : "HTTP_" + statusCode.value();
+        return Optional.ofNullable(HttpStatus.resolve(statusCode.value()))
+            .map(HttpStatus::name)
+            .orElse("HTTP_" + statusCode.value());
     }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilter.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilter.java
@@ -235,8 +235,7 @@ public class RequestResponseLogFilter extends OncePerRequestFilter {
             return "";
         }
 
-        String body = new String(content, getCharset(encoding));
-        return abbreviate(logMasker.maskText(body));
+        return abbreviate(logMasker.maskText(new String(content, getCharset(encoding))));
     }
 
     /**

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderController.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderController.java
@@ -2,7 +2,6 @@ package jp.co.shimizutdev.phoneorderapi.presentation.order;
 
 import jakarta.validation.Valid;
 import jp.co.shimizutdev.phoneorderapi.application.order.OrderService;
-import jp.co.shimizutdev.phoneorderapi.domain.order.Order;
 import jp.co.shimizutdev.phoneorderapi.presentation.error.ApiErrorResponseMessages;
 import jp.co.shimizutdev.phoneorderapi.presentation.generated.api.OrdersApi;
 import jp.co.shimizutdev.phoneorderapi.presentation.generated.model.OrderRequest;
@@ -45,13 +44,12 @@ public class OrderController implements OrdersApi {
      */
     @Override
     public OrderResponse getOrderByOrderCode(final String orderCode) {
-        Order order = orderService.getOrderByOrderCode(orderCode)
+        return orderService.getOrderByOrderCode(orderCode)
+            .map(OrderMapper::toResponse)
             .orElseThrow(() -> new ResponseStatusException(
                 HttpStatus.NOT_FOUND,
                 ApiErrorResponseMessages.ORDER_NOT_FOUND
             ));
-
-        return OrderMapper.toResponse(order);
     }
 
     /**
@@ -73,12 +71,11 @@ public class OrderController implements OrdersApi {
      */
     @Override
     public OrderResponse cancelOrder(final String orderCode) {
-        Order order = orderService.cancelOrder(orderCode)
+        return orderService.cancelOrder(orderCode)
+            .map(OrderMapper::toResponse)
             .orElseThrow(() -> new ResponseStatusException(
                 HttpStatus.NOT_FOUND,
                 ApiErrorResponseMessages.ORDER_NOT_FOUND
             ));
-
-        return OrderMapper.toResponse(order);
     }
 }


### PR DESCRIPTION
## 概要

presentation 層の例外処理と注文 API 実装を中心に、返却処理の書き方を簡潔化した。
あわせて `ApiExceptionHandler` の制約違反項目抽出を関数型で整理し、一部 infrastructure / log 実装の記述も統一した。

## Issue

close #111

## 対応内容

- `OrderController` の各 API メソッドで処理結果を直接返す形に整理
- `ApiExceptionHandler` のバリデーションエラー生成処理を簡潔化
- `ApiExceptionHandler#extractViolationField` を関数型で記述
- `ApiExceptionHandler#resolveErrorCode` を `Optional` ベースで整理
- `RequestResponseLogFilter` の body 生成処理を直接返却へ整理
- `SequentialOrderCodeGenerator` の連番変換処理を直接返却へ整理

## 完了条件

実装担当者がチェック

- [x] `OrderController` の返却処理が統一された書き方になっている
- [x] `ApiExceptionHandler` の例外レスポンス挙動が既存仕様と一致している
- [x] `extractViolationField` の関数型化で返却値が変わっていない
- [x] `RequestResponseLogFilter` と `SequentialOrderCodeGenerator` の挙動が変わっていない
- [x] 関連テストが通過している

## レビュー観点

レビュー担当者がチェック

- [x] `Optional.map(...).orElseThrow(...)` への変更で controller の可読性が維持できているか
- [x] `extractViolationField` の関数型化が命令型実装より読みやすくなっているか
- [x] `resolveErrorCode` の `Optional` 利用が過剰でないか
- [x] 今回の変更が単なる記述整理に留まっており、レスポンス内容に差分が出ていないか

## 備考（任意）

確認した関連テスト:
- `ApiExceptionHandlerTest`
- `OrderControllerTest`
- `RequestResponseLogFilterTest`

テスト実行コマンド:

```bash
./mvnw -q "-Dtest=ApiExceptionHandlerTest,OrderControllerTest,RequestResponseLogFilterTest" test
```
