### PR TITLE
refactor: 開発ルールの明文化とJPA・テストコードの整合性を整理する (#115)

### DIFF
--- a/docs/09_development/README.md
+++ b/docs/09_development/README.md
@@ -19,6 +19,12 @@
 - `git-commit-message.md`
 - `chatgpt-thread-guidelines.md`
 - `implementation-naming-rules.md`
+- `jpa-entity-and-mapper-rules.md`
+- `java-annotation-order-rules.md`
+- `java-final-usage-rules.md`
+- `lombok-usage-rules.md`
+- `spring-aop-implementation-rules.md`
+- `value-object-design-rules.md`
 - `validation-message-key-naming-rules.md`
 - `test-code-naming-and-javadoc-rules.md`
 - `log-operation-rules.md`

--- a/docs/09_development/java-annotation-order-rules.md
+++ b/docs/09_development/java-annotation-order-rules.md
@@ -1,0 +1,143 @@
+# Java アノテーション並び順ルール
+
+## 目的
+
+クラス宣言まわりのアノテーション順を統一し、可読性とレビュー基準を揃える。
+
+---
+
+## 基本方針
+
+- アルファベット順ではなく、意味の強さで並べる
+- 先に「そのクラスの役割を決めるもの」を置く
+- 次に「振る舞い・補助設定を決めるもの」を置く
+- Lombok は最後にまとめる
+
+基本順:
+
+1. 役割を決めるアノテーション
+2. 振る舞い・補助設定のアノテーション
+3. Lombok のアノテーション
+
+---
+
+## 役割を決めるアノテーション
+
+例:
+
+- `@RestController`
+- `@Service`
+- `@Repository`
+- `@Component`
+- `@Configuration`
+- `@Entity`
+- `@MappedSuperclass`
+- `@RestControllerAdvice`
+- `@SpringBootTest`
+- `@DataJpaTest`
+
+---
+
+## 振る舞い・補助設定のアノテーション
+
+例:
+
+- `@Transactional`
+- `@Order`
+- `@Table`
+- `@EntityListeners`
+- `@EnableJpaAuditing`
+- `@Import`
+- `@AutoConfigureMockMvc`
+- `@AutoConfigureTestDatabase`
+- `@SqlMergeMode`
+- `@Sql`
+- `@ExtendWith`
+
+---
+
+## Lombok のアノテーション
+
+例:
+
+- `@RequiredArgsConstructor`
+- `@Getter`
+- `@Setter`
+- `@NoArgsConstructor`
+- `@EqualsAndHashCode`
+- `@ToString`
+- `@Slf4j`
+
+---
+
+## 適用例
+
+### Spring Service
+
+```java
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderService {
+}
+```
+
+### JPA Entity
+
+```java
+
+@Entity
+@Table(name = "orders")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderJpaEntity {
+}
+```
+
+### JPA MappedSuperclass
+
+```java
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class BaseAuditJpaEntity {
+}
+```
+
+### Filter / Component
+
+```java
+
+@Component
+@Order(2)
+@Slf4j
+@RequiredArgsConstructor
+public class RequestResponseLogFilter {
+}
+```
+
+### Test Class
+
+```java
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(OutputCaptureExtension.class)
+class RequestResponseLogFilterTest {
+}
+```
+
+---
+
+## 補足
+
+- 同じ意味の層の中では、関連の強いものを近くに置く
+- 迷った場合は「このクラスが何者かを先に読める順」を優先する
+- 既存コードを修正するときは、このルールに合わせて並び順も揃える
+- メソッドやフィールドのアノテーション順は、必要になった時点で別途ルール化する
+

--- a/docs/09_development/java-final-usage-rules.md
+++ b/docs/09_development/java-final-usage-rules.md
@@ -1,0 +1,95 @@
+# Java `final` 使用ルール
+
+## 目的
+
+`final` の使用方針を統一し、可読性と設計意図を揃える。
+
+---
+
+## 基本方針
+
+- `final` は一律に付けない
+- 意味が明確な箇所にだけ付ける
+- Spring の AOP / Proxy と相性が悪くなる箇所には機械的に付けない
+
+---
+
+## 使用ルール
+
+### フィールド
+
+- 再代入しないフィールドには `final` を付ける
+- コンストラクタインジェクションの依存フィールドには `final` を付ける
+- 値オブジェクトや entity の不変項目には `final` を付ける
+
+例:
+
+```java
+private final OrderRepository orderRepository;
+private final String value;
+```
+
+---
+
+### 引数
+
+- 引数への `final` は許可する
+- このプロジェクトでは既存コードに合わせて付与してよい
+- ただし、付けるかどうかは可読性を下げない範囲で統一する
+
+例:
+
+```java
+public Optional<Order> getOrderByOrderCode(final String orderCode) {
+    // ...
+}
+```
+
+---
+
+### ローカル変数
+
+- 再代入しないことを明示したい場合のみ `final` を付ける
+- 一時変数すべてに機械的に付けない
+
+---
+
+### クラス
+
+- 値オブジェクトなど、継承させない意図を明示したい場合は `final` を付けてよい
+- ただし private constructor により実質的に継承不可であれば必須ではない
+- Spring 管理クラスに対しては、AOP や proxy の都合を確認してから付ける
+
+---
+
+### メソッド
+
+- 各メソッドに一律で `final` は付けない
+- `private` メソッドには付けない
+- Spring の `@Transactional` など、proxy / AOP 対象になりうる `public` メソッドには機械的に付けない
+- オーバーライド禁止に明確な設計意図がある場合だけ限定的に使用する
+
+例:
+
+```java
+public Order createOrder(final OffsetDateTime orderedAt) {
+    // ...
+}
+
+private String nullToEmpty(final String value) {
+    // ...
+}
+```
+
+上記のようなメソッドに `final` は付けない。
+
+---
+
+## このプロジェクトでの推奨
+
+- フィールドの `final` は積極的に使う
+- 引数の `final` は既存コードに合わせて使ってよい
+- ローカル変数の `final` は必要なときだけ使う
+- クラスの `final` は設計意図が明確なときだけ使う
+- メソッドの `final` は原則として使わない
+

--- a/docs/09_development/jpa-entity-and-mapper-rules.md
+++ b/docs/09_development/jpa-entity-and-mapper-rules.md
@@ -1,0 +1,86 @@
+# JPA Entity / Mapper ルール
+
+## 目的
+
+JPA Entity と domain object の責務を分離し、永続化まわりの実装判断を統一する。
+
+---
+
+## 基本方針
+
+- domain object と JPA entity は別物として扱う
+- domain は JPA に依存しない
+- JPA entity への変換と逆変換は mapper に集約する
+
+---
+
+## JPA Entity のルール
+
+- JPA entity は `infrastructure.persistence` 配下に置く
+- クラス名は `XxxJpaEntity` とする
+- DB カラムとの対応を表す責務に限定する
+- domain logic は持たせない
+- 値検証や業務ルールは domain 側に置く
+
+---
+
+## Mapper のルール
+
+- domain object と JPA entity の相互変換は mapper に集約する
+- クラス名は `XxxJpaMapper` とする
+- `toEntity` と `toDomain` を基本の入口にする
+- 変換時に永続化データの異常を検知したら、mapper で例外に変換する
+
+例:
+
+```java
+public static OrderJpaEntity toEntity(final Order order) {
+    // ...
+}
+
+public static Order toDomain(final OrderJpaEntity orderJpaEntity) {
+    // ...
+}
+```
+
+---
+
+## 依存方向のルール
+
+- domain は JPA entity を参照しない
+- application も原則として JPA entity を直接扱わない
+- repository 実装だけが mapper と JPA repository を使ってよい
+
+---
+
+## Entity の生成ルール
+
+- 本番コードでは JPA entity を mapper 経由で組み立てる
+- domain object から永続化表現へ落とす処理は `toEntity` に寄せる
+- 別パッケージから `new XxxJpaEntity()` を前提にしない
+
+---
+
+## テストコードのルール
+
+- 別パッケージのテストで JPA entity の constructor 可視性に依存しない
+- 可能なら mapper を使って entity を組み立てる
+- どうしても直接生成が必要な場合は、テスト配置か専用 factory を見直す
+
+---
+
+## Repository 実装のルール
+
+- domain repository の interface は domain に置く
+- JPA repository は infrastructure に置く
+- domain repository 実装は `XxxRepositoryImpl` とする
+- `RepositoryImpl` では JPA repository と mapper を組み合わせて domain を返す
+
+---
+
+## このプロジェクトでの推奨
+
+- `OrderRepositoryImpl` が `OrderJpaRepository` と `OrderJpaMapper` を使う構成を踏襲する
+- domain object の生成は domain 側 factory method で行う
+- JPA entity は永続化の都合だけを表現する
+

--- a/docs/09_development/lombok-usage-rules.md
+++ b/docs/09_development/lombok-usage-rules.md
@@ -1,0 +1,112 @@
+# Lombok 使用ルール
+
+## 目的
+
+Lombok の使用方針を統一し、可読性と設計意図を崩さずにボイラープレートを減らす。
+
+---
+
+## 基本方針
+
+- Lombok は記述量を減らすために使う
+- 設計意図が読みにくくなる使い方は避ける
+- Spring / JPA / domain model の都合を優先する
+
+---
+
+## 使用してよい主なアノテーション
+
+- `@RequiredArgsConstructor`
+- `@Getter`
+- `@Setter`
+- `@NoArgsConstructor`
+- `@EqualsAndHashCode`
+- `@ToString`
+- `@Slf4j`
+
+---
+
+## 使用ルール
+
+### Spring Bean
+
+- constructor injection を基本とする
+- 依存フィールドは `private final` にする
+- コンストラクタは `@RequiredArgsConstructor` で生成する
+
+例:
+
+```java
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final OrderCodeGenerator orderCodeGenerator;
+}
+```
+
+---
+
+### Domain Object / Value Object
+
+- `@Getter`, `@ToString`, `@EqualsAndHashCode` を必要に応じて使う
+- 生成方法やバリデーションは明示的にコードで書く
+- `@Data` は使わない
+- `@Value` は自動生成される constructor や運用方針と衝突しやすいため、このプロジェクトでは基本にしない
+
+---
+
+### JPA Entity
+
+- `@Getter`, `@Setter`, `@NoArgsConstructor` を使ってよい
+- `@NoArgsConstructor` は `access = AccessLevel.PROTECTED` を基本とする
+- `@Data` は使わない
+- `@EqualsAndHashCode` は使わない
+- `@ToString` は遅延ロードや循環参照の問題を招きうるため原則使わない
+
+例:
+
+```java
+@Entity
+@Table(name = "orders")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OrderJpaEntity {
+}
+```
+
+---
+
+### Logging
+
+- logger は `@Slf4j` を使用してよい
+- logger 名を明示したい特別な理由がなければ手書きしない
+
+---
+
+## 使用しない方がよいアノテーション
+
+### `@Data`
+
+- getter / setter / equals / hashCode / toString を一括生成するため影響範囲が広い
+- domain object や JPA entity では不要なメソッドまで増えやすい
+- 設計意図がぼやけるため、このプロジェクトでは使わない
+
+### `@AllArgsConstructor`
+
+- 生成ルールを曖昧にしやすい
+- factory method や `@RequiredArgsConstructor` の方針と競合しやすい
+- 特別な理由がない限り使わない
+
+---
+
+## このプロジェクトでの推奨
+
+- Spring Bean には `@RequiredArgsConstructor`
+- domain / value object には必要最小限の Lombok
+- JPA entity には `@Getter`, `@Setter`, `@NoArgsConstructor(access = AccessLevel.PROTECTED)`
+- `@Data` は使わない
+

--- a/docs/09_development/spring-aop-implementation-rules.md
+++ b/docs/09_development/spring-aop-implementation-rules.md
@@ -1,0 +1,80 @@
+# Spring / AOP 実装ルール
+
+## 目的
+
+Spring の proxy / AOP を前提にした実装上の注意点を統一し、動作不良や設計のぶれを防ぐ。
+
+---
+
+## 基本方針
+
+- Spring 管理クラスは Spring の proxy 前提で設計する
+- `@Transactional` や AOP の対象メソッドを、機械的な Java 流儀で壊さない
+- constructor injection を基本にする
+
+---
+
+## Bean 設計のルール
+
+- Spring Bean の依存は constructor injection にする
+- フィールドインジェクションは原則使わない
+- `@RequiredArgsConstructor` と `private final` を基本にする
+
+---
+
+## `final` のルール
+
+- Spring Bean の `public` メソッドに一律で `final` は付けない
+- `@Transactional` 対象メソッドに機械的に `final` を付けない
+- proxy / AOP の拡張余地を塞がないことを優先する
+
+---
+
+## `@Transactional` のルール
+
+- transaction 境界は application service に置くことを基本とする
+- class レベルの既定値と method レベルの上書きを使い分ける
+- 読み取り系は `@Transactional(readOnly = true)` を基本にする
+- 更新系は method レベルで `@Transactional` を付ける
+
+例:
+
+```java
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderService {
+
+    @Transactional
+    public Order createOrder(final OffsetDateTime orderedAt) {
+        // ...
+    }
+}
+```
+
+---
+
+## AOP 対象クラスのルール
+
+- ログや監視のアスペクト対象クラスでは、public API を素直に保つ
+- advice の適用を前提に、不要な `final` や複雑な継承を避ける
+- AOP で横断関心を扱い、業務ロジック本体に混ぜすぎない
+
+---
+
+## クラス設計のルール
+
+- Spring Bean は役割がわかるアノテーションを先に置く
+- 振る舞いを決めるアノテーションをその次に置く
+- Lombok は最後に置く
+- 詳細は `java-annotation-order-rules.md` に従う
+
+---
+
+## このプロジェクトでの推奨
+
+- service 層を transaction 境界とする
+- logging は aspect / filter に寄せる
+- constructor injection を徹底する
+- `public` メソッドの `final` は原則使わない
+

--- a/docs/09_development/value-object-design-rules.md
+++ b/docs/09_development/value-object-design-rules.md
@@ -1,0 +1,92 @@
+# バリューオブジェクト設計ルール
+
+## 目的
+
+バリューオブジェクトの作り方を統一し、不変条件を型に閉じ込める。
+
+---
+
+## 基本方針
+
+- raw な値をそのまま渡さず、意味のある型で包む
+- 不変条件は constructor / factory method 内で検証する
+- 小さく独立した型として定義する
+- 継承より自己完結した設計を優先する
+
+---
+
+## クラス設計のルール
+
+- 1つの値を表す小さな型として作る
+- フィールドは `private final`
+- constructor は `private` を基本とする
+- 生成は `of` などの factory method 経由にする
+
+例:
+
+```java
+public class OrderCode {
+
+    private final String value;
+
+    private OrderCode(final String value) {
+        // validation
+        this.value = value;
+    }
+
+    public static OrderCode of(final String value) {
+        return new OrderCode(value);
+    }
+}
+```
+
+---
+
+## バリデーションのルール
+
+- 不正な値は生成時に拒否する
+- `IllegalArgumentException` など明確な例外で失敗させる
+- 事前判定が有用な場合のみ `isValid` を持たせる
+- `isValid` は constructor / `of` の代替ではなく補助として扱う
+
+---
+
+## 命名のルール
+
+- `OrderCode`, `OrderId`, `OrderedAt` のように業務上の意味をそのまま名前にする
+- raw 型名を前面に出さない
+- 値へのアクセスは `getValue()` に揃える
+
+---
+
+## 共通化のルール
+
+- 基底クラスや共通 interface は安易に導入しない
+- 似ていても、不変条件や内部型が異なるなら個別クラスのままにする
+- 共通化するのは、実際に重複が痛くなってから検討する
+
+---
+
+## Lombok のルール
+
+- `@Getter`, `@ToString`, `@EqualsAndHashCode` は使ってよい
+- `@Data` は使わない
+- `@Value` はこのプロジェクトでは基本としない
+
+---
+
+## `final` の考え方
+
+- `final class` は必要なら付けてよい
+- ただし private constructor により実質的に継承不可なら必須ではない
+- 一貫性を重視する場合は、同種の value object で揃える
+
+---
+
+## このプロジェクトでの推奨
+
+- `OrderCode`, `OrderId`, `OrderedAt` のパターンを基本形とする
+- factory method で生成する
+- 値検証は生成時に行う
+- バリューオブジェクト用の基底クラスは導入しない
+

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderService.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderService.java
@@ -13,8 +13,8 @@ import java.util.Optional;
  * 注文サービス
  */
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class OrderService {
 
     /**

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderCode.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderCode.java
@@ -45,4 +45,14 @@ public class OrderCode {
     public static OrderCode of(final String value) {
         return new OrderCode(value);
     }
+
+    /**
+     * 注文コード文字列が有効形式か判定する
+     *
+     * @param value 注文コード文字列
+     * @return 判定結果
+     */
+    public static boolean isValid(final String value) {
+        return value != null && ORDER_CODE_PATTERN.matcher(value).matches();
+    }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderStatus.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderStatus.java
@@ -53,4 +53,17 @@ public enum OrderStatus {
             default -> throw new IllegalArgumentException("注文ステータスコードが不正です。");
         };
     }
+
+    /**
+     * 注文ステータスコードが有効か判定する
+     *
+     * @param code 注文ステータスコード
+     * @return 判定結果
+     */
+    public static boolean isValidCode(final String code) {
+        return switch (code) {
+            case "001", "002", "003", "004", "005", "006" -> true;
+            default -> false;
+        };
+    }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/BaseAuditJpaEntity.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/BaseAuditJpaEntity.java
@@ -3,6 +3,7 @@ package jp.co.shimizutdev.phoneorderapi.infrastructure.persistence;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -17,11 +18,11 @@ import java.time.OffsetDateTime;
 /**
  * 基底監査JPAエンティティ
  */
-@Getter
-@Setter
-@NoArgsConstructor
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class BaseAuditJpaEntity {
 
     /**

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/InvalidPersistedOrderException.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/InvalidPersistedOrderException.java
@@ -1,0 +1,16 @@
+package jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order;
+
+/**
+ * 永続化済み注文データがドメイン再構築できない場合の例外
+ */
+public class InvalidPersistedOrderException extends RuntimeException {
+
+    /**
+     * コンストラクタ
+     *
+     * @param message メッセージ
+     */
+    public InvalidPersistedOrderException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/InvalidPersistedOrderMessages.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/InvalidPersistedOrderMessages.java
@@ -1,0 +1,33 @@
+package jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order;
+
+/**
+ * 永続化済み注文データ不整合メッセージ
+ */
+public final class InvalidPersistedOrderMessages {
+
+    /**
+     * 注文ID不正メッセージ
+     */
+    public static final String INVALID_ORDER_ID = "永続化済み注文データの注文IDが不正です。";
+
+    /**
+     * 注文コード不正メッセージ
+     */
+    public static final String INVALID_ORDER_CODE = "永続化済み注文データの注文コードが不正です。";
+
+    /**
+     * 注文日時不正メッセージ
+     */
+    public static final String INVALID_ORDERED_AT = "永続化済み注文データの注文日時が不正です。";
+
+    /**
+     * 注文ステータス不正メッセージ
+     */
+    public static final String INVALID_ORDER_STATUS = "永続化済み注文データの注文ステータスが不正です。";
+
+    /**
+     * インスタンス化防止
+     */
+    private InvalidPersistedOrderMessages() {
+    }
+}

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaEntity.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaEntity.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.BaseAuditJpaEntity;
+import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -15,11 +16,11 @@ import java.util.UUID;
 /**
  * 注文JPAエンティティ
  */
-@Getter
-@Setter
-@NoArgsConstructor
 @Entity
 @Table(name = "orders")
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderJpaEntity extends BaseAuditJpaEntity {
 
     /**

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaMapper.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaMapper.java
@@ -25,10 +25,10 @@ public class OrderJpaMapper {
      */
     public static Order toDomain(final OrderJpaEntity orderJpaEntity) {
         return Order.reconstruct(
-            OrderId.of(orderJpaEntity.getId()),
-            OrderCode.of(orderJpaEntity.getOrderCode()),
-            OrderedAt.of(orderJpaEntity.getOrderedAt()),
-            OrderStatus.fromCode(orderJpaEntity.getOrderStatus())
+            toOrderId(orderJpaEntity),
+            toOrderCode(orderJpaEntity),
+            toOrderedAt(orderJpaEntity),
+            toOrderStatus(orderJpaEntity)
         );
     }
 
@@ -47,5 +47,61 @@ public class OrderJpaMapper {
         orderJpaEntity.setCreatedBy(SYSTEM_USER);
         orderJpaEntity.setUpdatedBy(SYSTEM_USER);
         return orderJpaEntity;
+    }
+
+    /**
+     * 注文IDを再構築する
+     *
+     * @param orderJpaEntity 注文JPAエンティティ
+     * @return 注文ID
+     */
+    private static OrderId toOrderId(final OrderJpaEntity orderJpaEntity) {
+        if (orderJpaEntity.getId() == null) {
+            throw new InvalidPersistedOrderException(InvalidPersistedOrderMessages.INVALID_ORDER_ID);
+        }
+
+        return OrderId.of(orderJpaEntity.getId());
+    }
+
+    /**
+     * 注文コードを再構築する
+     *
+     * @param orderJpaEntity 注文JPAエンティティ
+     * @return 注文コード
+     */
+    private static OrderCode toOrderCode(final OrderJpaEntity orderJpaEntity) {
+        if (!OrderCode.isValid(orderJpaEntity.getOrderCode())) {
+            throw new InvalidPersistedOrderException(InvalidPersistedOrderMessages.INVALID_ORDER_CODE);
+        }
+
+        return OrderCode.of(orderJpaEntity.getOrderCode());
+    }
+
+    /**
+     * 注文日時を再構築する
+     *
+     * @param orderJpaEntity 注文JPAエンティティ
+     * @return 注文日時
+     */
+    private static OrderedAt toOrderedAt(final OrderJpaEntity orderJpaEntity) {
+        if (orderJpaEntity.getOrderedAt() == null) {
+            throw new InvalidPersistedOrderException(InvalidPersistedOrderMessages.INVALID_ORDERED_AT);
+        }
+
+        return OrderedAt.of(orderJpaEntity.getOrderedAt());
+    }
+
+    /**
+     * 注文ステータスを再構築する
+     *
+     * @param orderJpaEntity 注文JPAエンティティ
+     * @return 注文ステータス
+     */
+    private static OrderStatus toOrderStatus(final OrderJpaEntity orderJpaEntity) {
+        if (!OrderStatus.isValidCode(orderJpaEntity.getOrderStatus())) {
+            throw new InvalidPersistedOrderException(InvalidPersistedOrderMessages.INVALID_ORDER_STATUS);
+        }
+
+        return OrderStatus.fromCode(orderJpaEntity.getOrderStatus());
     }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandler.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Path;
 import jp.co.shimizutdev.phoneorderapi.domain.order.OrderCannotBeCancelledException;
+import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.InvalidPersistedOrderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -145,6 +146,29 @@ public class ApiExceptionHandler {
         return buildErrorResponse(
             HttpStatus.CONFLICT,
             ApiErrorResponseMessages.ORDER_CANNOT_BE_CANCELLED,
+            request,
+            List.of()
+        );
+    }
+
+    /**
+     * 永続化済みデータ不整合を 500 Internal Server Error に変換する。
+     *
+     * @param ex      永続化済みデータ不整合例外
+     * @param request HTTP リクエスト
+     * @return API エラーレスポンス
+     */
+    @SuppressWarnings("unused")
+    @ExceptionHandler(InvalidPersistedOrderException.class)
+    public ResponseEntity<ApiErrorResponse> handleInvalidPersistedOrderException(
+        final InvalidPersistedOrderException ex,
+        final HttpServletRequest request) {
+
+        log.error("永続化済み注文データが不正です。path={}, message={}", request.getRequestURI(), ex.getMessage(), ex);
+
+        return buildErrorResponse(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            ApiErrorResponseMessages.INTERNAL_SERVER_ERROR,
             request,
             List.of()
         );

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceTest.java
@@ -1,8 +1,8 @@
 package jp.co.shimizutdev.phoneorderapi.application.order;
 
-import jp.co.shimizutdev.phoneorderapi.domain.order.Order;
-import jp.co.shimizutdev.phoneorderapi.domain.order.OrderCannotBeCancelledException;
+import jp.co.shimizutdev.phoneorderapi.domain.order.*;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.OrderJpaEntity;
+import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.OrderJpaMapper;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.OrderJpaRepository;
 import jp.co.shimizutdev.phoneorderapi.support.AbstractPostgreSQLTest;
 import org.junit.jupiter.api.AfterEach;
@@ -170,13 +170,13 @@ class OrderServiceTest extends AbstractPostgreSQLTest {
      * @return 注文JPAエンティティ
      */
     private OrderJpaEntity reconstructOrderJpaEntity(final String orderCode, final String orderStatus) {
-        OrderJpaEntity order = new OrderJpaEntity();
-        order.setId(UUID.randomUUID());
-        order.setOrderCode(orderCode);
-        order.setOrderedAt(OffsetDateTime.now());
-        order.setOrderStatus(orderStatus);
-        order.setCreatedBy("system");
-        order.setUpdatedBy("system");
-        return order;
+        Order order = Order.reconstruct(
+            OrderId.of(UUID.randomUUID()),
+            OrderCode.of(orderCode),
+            OrderedAt.of(OffsetDateTime.now()),
+            OrderStatus.fromCode(orderStatus)
+        );
+
+        return OrderJpaMapper.toEntity(order);
     }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepositoryTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepositoryTest.java
@@ -3,6 +3,7 @@ package jp.co.shimizutdev.phoneorderapi.domain.order;
 import jakarta.persistence.EntityManager;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.config.JpaAuditConfig;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.OrderJpaEntity;
+import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.OrderJpaMapper;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.OrderJpaRepository;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.repository.order.OrderRepositoryImpl;
 import jp.co.shimizutdev.phoneorderapi.support.AbstractPostgreSQLTest;
@@ -26,8 +27,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * 注文リポジトリテスト
  */
 @DataJpaTest
-@Import({JpaAuditConfig.class, OrderRepositoryImpl.class})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({JpaAuditConfig.class, OrderRepositoryImpl.class})
 class OrderRepositoryTest extends AbstractPostgreSQLTest {
 
     /**
@@ -250,13 +251,16 @@ class OrderRepositoryTest extends AbstractPostgreSQLTest {
         final OffsetDateTime orderedAt,
         final String orderStatus) {
 
-        OrderJpaEntity order = new OrderJpaEntity();
-        order.setId(orderId);
-        order.setOrderCode(orderCode);
-        order.setOrderedAt(orderedAt);
-        order.setOrderStatus(orderStatus);
-        order.setCreatedBy("system");
-        order.setUpdatedBy("before-update");
-        return order;
+        Order order = Order.reconstruct(
+            OrderId.of(orderId),
+            OrderCode.of(orderCode),
+            OrderedAt.of(orderedAt),
+            OrderStatus.fromCode(orderStatus)
+        );
+
+        OrderJpaEntity orderJpaEntity = OrderJpaMapper.toEntity(order);
+        orderJpaEntity.setUpdatedBy("before-update");
+
+        return orderJpaEntity;
     }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectTest.java
@@ -19,8 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * メソッド開始/終了ログ出力アスペクトテスト
  */
-@ExtendWith(OutputCaptureExtension.class)
 @SpringBootTest
+@ExtendWith(OutputCaptureExtension.class)
 @SqlMergeMode(MergeMode.MERGE)
 @Sql(
     scripts = "classpath:sql/cleanup/cleanup-transaction-tables.sql",

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandlerTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandlerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.InvalidPersistedOrderException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,17 @@ class ApiExceptionHandlerTest {
             .build();
     }
 
+    /**
+     * <pre>
+     * IllegalArgumentException発生時に400エラーレスポンスを返すこと。
+     *
+     * Given IllegalArgumentExceptionを送出するAPIがある
+     * When IllegalArgumentException発生APIを実行する
+     * Then 400 Bad Requestのエラーレスポンスが返る
+     * </pre>
+     *
+     * @throws Exception 例外
+     */
     @Test
     @DisplayName("IllegalArgumentException is mapped to 400")
     void shouldReturnBadRequestWhenIllegalArgumentExceptionOccurs() throws Exception {
@@ -55,6 +67,17 @@ class ApiExceptionHandlerTest {
             .andExpect(jsonPath("$.validationErrors").isArray());
     }
 
+    /**
+     * <pre>
+     * メッセージなしIllegalArgumentException発生時にバリデーションエラーメッセージで400エラーレスポンスを返すこと。
+     *
+     * Given メッセージなしIllegalArgumentExceptionを送出するAPIがある
+     * When メッセージなしIllegalArgumentException発生APIを実行する
+     * Then 400 Bad Requestとバリデーションエラーメッセージのエラーレスポンスが返る
+     * </pre>
+     *
+     * @throws Exception 例外
+     */
     @Test
     @DisplayName("IllegalArgumentException without a message falls back to the validation error message")
     void shouldReturnValidationErrorMessageWhenIllegalArgumentExceptionHasNoMessage() throws Exception {
@@ -67,6 +90,17 @@ class ApiExceptionHandlerTest {
             .andExpect(jsonPath("$.validationErrors").isArray());
     }
 
+    /**
+     * <pre>
+     * バリデーションエラー発生時に400エラーレスポンスを返すこと。
+     *
+     * Given バリデーションエラーとなるリクエストを受け付けるAPIがある
+     * When 必須項目不足のリクエストでAPIを実行する
+     * Then 400 Bad Requestとバリデーションエラー詳細が返る
+     * </pre>
+     *
+     * @throws Exception 例外
+     */
     @Test
     @DisplayName("Validation errors are mapped to 400")
     void shouldReturnBadRequestWhenValidationErrorOccurs() throws Exception {
@@ -82,6 +116,17 @@ class ApiExceptionHandlerTest {
             .andExpect(jsonPath("$.validationErrors[0].message").value("name is required."));
     }
 
+    /**
+     * <pre>
+     * 非標準のHTTPステータスコードを指定したResponseStatusException発生時にそのステータスを保持して返すこと。
+     *
+     * Given 非標準ステータスコードのResponseStatusExceptionを送出するAPIがある
+     * When カスタムステータス例外発生APIを実行する
+     * Then 指定した非標準ステータスコードのエラーレスポンスが返る
+     * </pre>
+     *
+     * @throws Exception 例外
+     */
     @Test
     @DisplayName("Non-standard response statuses are preserved")
     void shouldReturnCustomStatusWhenResponseStatusExceptionUsesNonStandardCode() throws Exception {
@@ -93,6 +138,17 @@ class ApiExceptionHandlerTest {
             .andExpect(jsonPath("$.path").value("/test/errors/custom-status"));
     }
 
+    /**
+     * <pre>
+     * 想定外例外発生時に汎用的な500エラーレスポンスを返すこと。
+     *
+     * Given 想定外例外を送出するAPIがある
+     * When 想定外例外発生APIを実行する
+     * Then 500 Internal Server Errorと汎用エラーメッセージが返る
+     * </pre>
+     *
+     * @throws Exception 例外
+     */
     @Test
     @DisplayName("Unexpected exceptions are hidden behind a generic 500 response")
     void shouldReturnInternalServerErrorWhenUnexpectedExceptionOccurs() throws Exception {
@@ -102,6 +158,29 @@ class ApiExceptionHandlerTest {
             .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
             .andExpect(jsonPath("$.message").value(ApiErrorResponseMessages.INTERNAL_SERVER_ERROR))
             .andExpect(jsonPath("$.path").value("/test/errors/unexpected"));
+    }
+
+    /**
+     * <pre>
+     * InvalidPersistedOrderException発生時に500エラーレスポンスを返すこと。
+     *
+     * Given InvalidPersistedOrderExceptionを送出するAPIがある
+     * When InvalidPersistedOrderException発生APIを実行する
+     * Then 500 Internal Server Errorのエラーレスポンスが返る
+     * </pre>
+     *
+     * @throws Exception 例外
+     */
+    @Test
+    @DisplayName("InvalidPersistedOrderException is mapped to 500")
+    void shouldReturnInternalServerErrorWhenInvalidPersistedOrderExceptionOccurs() throws Exception {
+        mockMvc.perform(get("/test/errors/invalid-persisted-order"))
+            .andExpect(status().isInternalServerError())
+            .andExpect(jsonPath("$.status").value(500))
+            .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
+            .andExpect(jsonPath("$.message").value(ApiErrorResponseMessages.INTERNAL_SERVER_ERROR))
+            .andExpect(jsonPath("$.path").value("/test/errors/invalid-persisted-order"))
+            .andExpect(jsonPath("$.validationErrors").isArray());
     }
 
     @RestController
@@ -131,6 +210,11 @@ class ApiExceptionHandlerTest {
         @GetMapping("/unexpected")
         String throwUnexpectedException() {
             throw new IllegalStateException("boom");
+        }
+
+        @GetMapping("/invalid-persisted-order")
+        String throwInvalidPersistedOrderException() {
+            throw new InvalidPersistedOrderException("persisted order is invalid");
         }
     }
 

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterTest.java
@@ -20,9 +20,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * リクエスト/レスポンスのログを出力するフィルタテスト
  */
-@ExtendWith(OutputCaptureExtension.class)
 @SpringBootTest
 @AutoConfigureMockMvc
+@ExtendWith(OutputCaptureExtension.class)
 class RequestResponseLogFilterTest extends AbstractPostgreSQLTest {
 
     @Autowired

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerTest.java
@@ -205,6 +205,32 @@ class OrderControllerTest extends AbstractPostgreSQLTest {
                 .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001"))
                 .andExpect(jsonPath("$.validationErrors", hasSize(0)));
         }
+
+        /**
+         * <pre>
+         * DB上の注文ステータスが不正な場合は500を返すこと。
+         *
+         * Given DBに不正な注文ステータスの注文データが登録されている
+         * When 注文コードで注文取得APIを実行する
+         * Then 500 Internal Server Error が返る
+         * </pre>
+         *
+         * @throws Exception 例外
+         */
+        @Test
+        @DisplayName("DB上の注文ステータスが不正な場合は500を返すこと")
+        @Sql(statements = {
+            "insert into orders (id, order_code, ordered_at, order_status, created_by, updated_by) values (gen_random_uuid(), 'ORD000001', now(), '999', 'system', 'system')"
+        })
+        void shouldReturnInternalServerErrorWhenPersistedOrderStatusIsInvalid() throws Exception {
+            mockMvc.perform(get("/api/v1/orders/{orderCode}", "ORD000001"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.status").value(500))
+                .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.message").value(ApiErrorResponseMessages.INTERNAL_SERVER_ERROR))
+                .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001"))
+                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 概要

開発ルールの明文化を進めるとともに、JPA entity の constructor 可視性見直しに伴うテストコードの整合性を整理しました。  
あわせて、アノテーション順、`final` 使用方針、Lombok / JPA / value object / Spring AOP のルールを `docs/09_development` に追加し、テスト Javadoc の記載方針にも揃えています。

## Issue

close #115

## 対応内容・方針

- `docs/09_development` に以下のルール文書を追加
  - `java-annotation-order-rules.md`
  - `java-final-usage-rules.md`
  - `lombok-usage-rules.md`
  - `jpa-entity-and-mapper-rules.md`
  - `value-object-design-rules.md`
  - `spring-aop-implementation-rules.md`
- `docs/09_development/README.md` に追加文書への索引を追記
- `BaseAuditJpaEntity` / `OrderJpaEntity` の no-args constructor を `protected` に変更
- 上記変更に追従して、`OrderServiceTest` / `OrderRepositoryTest` の entity 生成を mapper ベースに修正
- クラスレベルのアノテーション順を `役割` → `振る舞い/補助設定` → `Lombok` に統一
- `ApiExceptionHandlerTest` に Given / When / Then 形式の Javadoc を追加
- 他のテストクラスも確認し、同種の Javadoc 不足がないことを確認
- `InvalidPersistedOrderException` の未使用コンストラクタを削除

## 対応後の確認

動作確認項目の確認がチェックできて

- [x] `.\\mvnw.cmd -q -DskipTests compile`
- [x] `.\\mvnw.cmd -q test-compile`

## レビュー観点

レビュー観点の確認がチェックできて

- [x] 追加した開発ルール文書の粒度と置き場所が妥当か
- [x] JPA entity の `protected` constructor 方針が今後の実装方針として問題ないか
- [x] テストコードの entity 生成を mapper 経由に寄せた方針が妥当か
- [x] アノテーション順の統一方針が既存コードベースに馴染むか
- [x] テスト Javadoc の記載内容が既存ルールと整合しているか

## 補足・参考

- 主な変更対象
  - `docs/09_development/README.md`
  - `docs/09_development/java-annotation-order-rules.md`
  - `docs/09_development/java-final-usage-rules.md`
  - `docs/09_development/lombok-usage-rules.md`
  - `docs/09_development/jpa-entity-and-mapper-rules.md`
  - `docs/09_development/value-object-design-rules.md`
  - `docs/09_development/spring-aop-implementation-rules.md`
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderService.java`
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/BaseAuditJpaEntity.java`
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaEntity.java`
  - `src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/InvalidPersistedOrderException.java`
  - `src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceTest.java`
  - `src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepositoryTest.java`
  - `src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectTest.java`
  - `src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandlerTest.java`
  - `src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterTest.java`