### PR TITLE
refactor: ログ出力の最適化と traceId・監査ユーザー解決の改善 (#118)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,16 @@
           </excludes>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+          </argLine>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/config/JpaAuditConfig.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/config/JpaAuditConfig.java
@@ -1,9 +1,14 @@
 package jp.co.shimizutdev.phoneorderapi.infrastructure.config;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
+import org.springframework.util.StringUtils;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -13,12 +18,51 @@ import java.util.Optional;
 public class JpaAuditConfig {
 
     /**
+     * 監査ユーザーを解決するために参照するヘッダー名一覧
+     */
+    private static final List<String> AUDITOR_HEADER_NAMES = List.of(
+        "X-User-Id",
+        "X-User-Name",
+        "X-Actor"
+    );
+
+    /**
      * 監査担当者を取得する
      *
      * @return 監査担当者
      */
     @Bean
     public AuditorAware<String> auditorAware() {
-        return () -> Optional.of("system");
+        return () -> currentRequest()
+            .map(this::resolveAuditor)
+            .filter(StringUtils::hasText)
+            .or(() -> Optional.of("system"));
+    }
+
+    /**
+     * 現在の HTTP リクエストを取得する
+     *
+     * @return HTTP リクエスト
+     */
+    private Optional<HttpServletRequest> currentRequest() {
+        return Optional.ofNullable(RequestContextHolder.getRequestAttributes())
+            .filter(ServletRequestAttributes.class::isInstance)
+            .map(ServletRequestAttributes.class::cast)
+            .map(ServletRequestAttributes::getRequest);
+    }
+
+    /**
+     * リクエストヘッダーから監査ユーザーを解決する
+     *
+     * @param request HTTP リクエスト
+     * @return 監査ユーザー
+     */
+    private String resolveAuditor(final HttpServletRequest request) {
+        return AUDITOR_HEADER_NAMES.stream()
+            .map(request::getHeader)
+            .filter(StringUtils::hasText)
+            .map(String::trim)
+            .findFirst()
+            .orElse(null);
     }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspect.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspect.java
@@ -47,6 +47,7 @@ public class MethodLogAspect {
             + "execution(* jp.co.shimizutdev.phoneorderapi.application..*Service.*(..)) || "
             + "execution(* jp.co.shimizutdev.phoneorderapi.infrastructure.repository..*RepositoryImpl.*(..))"
     )
+    @SuppressWarnings("unused")
     public Object logMethod(final ProceedingJoinPoint joinPoint) throws Throwable {
         MethodSignature signature = (MethodSignature) joinPoint.getSignature();
         String className = signature.getDeclaringType().getSimpleName();
@@ -57,7 +58,14 @@ public class MethodLogAspect {
         stopWatch.start();
 
         log.info("[method start] methodName: {}", methodDisplayName);
-        log.info("[method start] arguments: [{}] {}", getRuntimeTypeName(joinPoint.getArgs()), abbreviate(logMasker.maskObject(joinPoint.getArgs())));
+
+        if (log.isDebugEnabled()) {
+            log.debug(
+                "[method start] arguments: [{}] {}",
+                getRuntimeTypeName(joinPoint.getArgs()),
+                abbreviate(logMasker.maskObject(joinPoint.getArgs()))
+            );
+        }
 
         try {
             Object returnValue = joinPoint.proceed();
@@ -65,12 +73,15 @@ public class MethodLogAspect {
             stopWatch.stop();
 
             log.info("[method end] methodName: {}", methodDisplayName);
-            log.info(
-                "[method end] return value: [{}] {}",
-                getDeclaredReturnTypeName(signature, returnValue),
-                abbreviate(logMasker.maskObject(returnValue))
-            );
             log.info("[method end] duration(ms): {}", stopWatch.getTotalTimeMillis());
+
+            if (log.isDebugEnabled()) {
+                log.debug(
+                    "[method end] return value: [{}] {}",
+                    getDeclaredReturnTypeName(signature, returnValue),
+                    abbreviate(logMasker.maskObject(returnValue))
+                );
+            }
 
             return returnValue;
         } catch (Throwable ex) {
@@ -118,6 +129,7 @@ public class MethodLogAspect {
         if (value == null) {
             return "null";
         }
+
         return value.getClass().getSimpleName();
     }
 

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaMapper.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaMapper.java
@@ -6,10 +6,6 @@ import jp.co.shimizutdev.phoneorderapi.domain.order.*;
  * 注文JPAマッパー
  */
 public class OrderJpaMapper {
-    /**
-     * システムユーザ
-     */
-    private static final String SYSTEM_USER = "system";
 
     /**
      * コンストラクタ(インスタンス化を防止)
@@ -44,8 +40,6 @@ public class OrderJpaMapper {
         orderJpaEntity.setOrderCode(order.getOrderCode().getValue());
         orderJpaEntity.setOrderedAt(order.getOrderedAt().getValue());
         orderJpaEntity.setOrderStatus(order.getOrderStatus().getCode());
-        orderJpaEntity.setCreatedBy(SYSTEM_USER);
-        orderJpaEntity.setUpdatedBy(SYSTEM_USER);
         return orderJpaEntity;
     }
 

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/repository/order/OrderRepositoryImpl.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/repository/order/OrderRepositoryImpl.java
@@ -81,7 +81,6 @@ public class OrderRepositoryImpl implements OrderRepository {
             .orElseThrow(() -> new IllegalStateException("更新対象の注文が見つかりません。"));
 
         orderJpaEntity.setOrderStatus(order.getOrderStatus().getCode());
-        orderJpaEntity.setUpdatedBy("system");
 
         return OrderJpaMapper.toDomain(orderJpaEntity);
     }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilter.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilter.java
@@ -114,12 +114,15 @@ public class RequestResponseLogFilter extends OncePerRequestFilter {
     private void logRequest(final ContentCachingRequestWrapper request) {
         log.info("[request] http method: {}", request.getMethod());
         log.info("[request] request uri: {}", request.getRequestURI());
-        log.info("[request] query string: {}", nullToEmpty(request.getQueryString()));
-        log.info("[request] parameters: {}", getParameters(request));
         log.info("[request] content-type: {}", nullToEmpty(request.getContentType()));
         log.info("[request] client ip: {}", getClientIpAddress(request));
         log.info("[request] request id: {}", getRequestId(request));
-        log.info("[request] headers: {}", getHeaders(request));
+
+        if (log.isDebugEnabled()) {
+            log.debug("[request] query string: {}", nullToEmpty(request.getQueryString()));
+            log.debug("[request] parameters: {}", getParameters(request));
+            log.debug("[request] headers: {}", getHeaders(request));
+        }
     }
 
     /**
@@ -172,13 +175,16 @@ public class RequestResponseLogFilter extends OncePerRequestFilter {
         final long durationMillis,
         final Exception exception) {
 
-        log.info("[request] body: {}", getRequestBody(request));
         log.info("[response] status: {}", response.getStatus());
         log.info("[response] content-type: {}", nullToEmpty(response.getContentType()));
-        log.info("[response] headers: {}", getHeaders(response));
-        log.info("[response] body: {}", getResponseBody(response));
-        log.info("[response] size(bytes): {}", response.getContentAsByteArray().length);
         log.info("[response] duration(ms): {}", durationMillis);
+
+        if (log.isDebugEnabled()) {
+            log.debug("[request] body: {}", getRequestBody(request));
+            log.debug("[response] headers: {}", getHeaders(response));
+            log.debug("[response] body: {}", getResponseBody(response));
+            log.debug("[response] size(bytes): {}", response.getContentAsByteArray().length);
+        }
 
         if (exception != null) {
             log.warn("[exception] class: {}", exception.getClass().getName());

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilter.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilter.java
@@ -28,6 +28,21 @@ public class TraceIdFilter extends OncePerRequestFilter {
     public static final String TRACE_ID_KEY = "traceId";
 
     /**
+     * リクエストから traceId を引き継ぐためのヘッダー名
+     */
+    private static final String REQUEST_ID_HEADER = "X-Request-Id";
+
+    /**
+     * リクエストから correlationId を引き継ぐためのヘッダー名
+     */
+    private static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+
+    /**
+     * レスポンスへ traceId を返却するためのヘッダー名
+     */
+    private static final String TRACE_ID_HEADER = "X-Trace-Id";
+
+    /**
      * トレースIDを設定してフィルタチェーンを実行する。
      *
      * @param request     HTTPリクエスト
@@ -42,11 +57,35 @@ public class TraceIdFilter extends OncePerRequestFilter {
         @NonNull final HttpServletResponse response,
         @NonNull final FilterChain filterChain) throws ServletException, IOException {
 
+        String traceId = resolveTraceId(request);
+
         try {
-            MDC.put(TRACE_ID_KEY, UUID.randomUUID().toString());
+            MDC.put(TRACE_ID_KEY, traceId);
+            response.setHeader(TRACE_ID_HEADER, traceId);
             filterChain.doFilter(request, response);
         } finally {
             MDC.remove(TRACE_ID_KEY);
         }
+    }
+
+    /**
+     * リクエストから traceId を解決する
+     *
+     * @param request HTTP リクエスト
+     * @return traceId
+     */
+    private String resolveTraceId(final HttpServletRequest request) {
+        String requestId = request.getHeader(REQUEST_ID_HEADER);
+
+        if (requestId != null && !requestId.isBlank()) {
+            return requestId.trim();
+        }
+
+        String correlationId = request.getHeader(CORRELATION_ID_HEADER);
+        if (correlationId != null && !correlationId.isBlank()) {
+            return correlationId.trim();
+        }
+
+        return UUID.randomUUID().toString();
     }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceTest.java
@@ -11,6 +11,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -120,6 +123,34 @@ class OrderServiceTest extends AbstractPostgreSQLTest {
 
     /**
      * <pre>
+     * リクエストヘッダーのユーザー情報が監査項目へ反映されること。
+     *
+     * Given X-User-Id を含むリクエストコンテキストを設定する
+     * When 注文を作成する
+     * Then createdBy と updatedBy にリクエストユーザーが保存される
+     * </pre>
+     */
+    @Test
+    @DisplayName("リクエストヘッダーのユーザー情報が監査項目へ反映されること")
+    void shouldUseRequestUserForAuditWhenCreatingOrder() {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-User-Id", "user-123");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        try {
+            Order createdOrder = orderService.createOrder(OffsetDateTime.now());
+
+            Optional<OrderJpaEntity> actual = orderJpaRepository.findByOrderCode(createdOrder.getOrderCode().getValue());
+            assertTrue(actual.isPresent());
+            assertEquals("user-123", actual.get().getCreatedBy());
+            assertEquals("user-123", actual.get().getUpdatedBy());
+        } finally {
+            RequestContextHolder.resetRequestAttributes();
+        }
+    }
+
+    /**
+     * <pre>
      * 注文をキャンセルできること。
      *
      * Given 注文データが保存されている
@@ -140,6 +171,34 @@ class OrderServiceTest extends AbstractPostgreSQLTest {
         Optional<OrderJpaEntity> savedOrder = orderJpaRepository.findByOrderCode("ORD000001");
         assertTrue(savedOrder.isPresent());
         assertEquals("006", savedOrder.get().getOrderStatus());
+    }
+
+    /**
+     * <pre>
+     * リクエストヘッダーのユーザー情報が更新監査項目へ反映されること。
+     *
+     * Given 既存注文と X-User-Id を含むリクエストコンテキストを用意する
+     * When 注文をキャンセルする
+     * Then updatedBy にリクエストユーザーが保存される
+     * </pre>
+     */
+    @Test
+    @DisplayName("リクエストヘッダーのユーザー情報が更新監査項目へ反映されること")
+    void shouldUseRequestUserForAuditWhenCancellingOrder() {
+        orderJpaRepository.save(reconstructOrderJpaEntity("ORD000001", "001"));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("X-User-Id", "operator-1");
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
+        try {
+            orderService.cancelOrder("ORD000001");
+
+            Optional<OrderJpaEntity> savedOrder = orderJpaRepository.findByOrderCode("ORD000001");
+            assertTrue(savedOrder.isPresent());
+            assertEquals("operator-1", savedOrder.get().getUpdatedBy());
+        } finally {
+            RequestContextHolder.resetRequestAttributes();
+        }
     }
 
     /**

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilterTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilterTest.java
@@ -51,6 +51,31 @@ class TraceIdFilterTest {
 
     /**
      * <pre>
+     * X-Request-Id が存在する場合はその値を traceId として引き継ぐこと。
+     *
+     * Given X-Request-Id ヘッダーを含むリクエストを用意する
+     * When フィルタを実行する
+     * Then MDC とレスポンスヘッダーに同じ traceId が設定される
+     * </pre>
+     */
+    @Test
+    @DisplayName("X-Request-Id を traceId として引き継ぐこと")
+    void shouldReuseRequestIdHeaderAsTraceId() {
+        TraceIdFilter traceIdFilter = new TraceIdFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("X-Request-Id", "request-123");
+        AtomicReference<String> actualTraceId = new AtomicReference<>();
+        FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
+
+        assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
+
+        assertEquals("request-123", actualTraceId.get());
+        assertEquals("request-123", response.getHeader("X-Trace-Id"));
+    }
+
+    /**
+     * <pre>
      * フィルタチェーン実行後にトレースIDが削除されること。
      *
      * Given トレースIDフィルタを用意する


### PR DESCRIPTION
## 概要

ログ出力の最適化、traceId の引き継ぎ改善、監査ユーザー解決の見直しを行いました。
あわせて、Mockito の dynamic agent 自己アタッチ警告を抑止する設定を追加しています。

## Issue

close #118

## 対応内容・方針

- リクエスト/レスポンス本文、ヘッダー、メソッド引数、戻り値のログを `DEBUG` レベルに変更
- `INFO` レベルでは HTTP メソッド、URI、content-type、status、duration などの運用メタ情報を出力
- `X-Request-Id` または `X-Correlation-Id` を優先して traceId として採用
- レスポンスヘッダー `X-Trace-Id` に traceId を返却
- JPA 監査ユーザーを `X-User-Id`、`X-User-Name`、`X-Actor` の順で解決し、未設定時のみ `system` にフォールバック
- Mockito の警告抑止のため、Surefire に `javaagent` 設定を追加
- 追加した定数・メソッドの Javadoc を整備
- AOP のアドバイスメソッドに対する IDE の未使用警告を抑止

## 完了条件

完了条件の確認がチェック

- [x] リクエスト/レスポンス本文とメソッド引数/戻り値が `INFO` ではなく `DEBUG` で出力される
- [x] `X-Request-Id` を渡した場合、その値が traceId として利用される
- [x] レスポンスに `X-Trace-Id` が設定される
- [x] 監査項目 `createdBy` / `updatedBy` にリクエストヘッダー由来のユーザーが保存される
- [x] ヘッダー未指定時は `system` にフォールバックする
- [x] `./mvnw test` が成功する

## レビュー観点

レビュー観点の確認がチェック

- [x] ログレベルの変更方針が運用要件に合っているか
- [x] traceId の優先順位 `X-Request-Id` -> `X-Correlation-Id` -> UUID が妥当か
- [x] 監査ユーザーの解決対象ヘッダー `X-User-Id` / `X-User-Name` / `X-Actor` が妥当か
- [x] Mockito の `javaagent` 設定が CI / ローカル双方で問題ないか

## 補足・懸念事項

- Issue 番号は未設定のため `close #` は適宜置き換えてください
- ログの本文やヘッダーは `DEBUG` でのみ出力されるため、障害解析時はログレベル設定に注意が必要です