### PR TITLE
refactor: テスト時のログ設定を整理 (#130)

### DIFF
--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,3 +1,4 @@
+# suppress inspection "UnusedProperty" for whole file
 # ========================
 # Datasource
 # ========================

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+# suppress inspection "UnusedProperty" for whole file
 # ========================
 # Spring
 # ========================

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepositoryTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepositoryTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * 注文リポジトリテスト
  */
-@DataJpaTest
+@DataJpaTest(showSql = false)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({JpaAuditConfig.class, OrderRepositoryImpl.class})
 class OrderRepositoryTest extends AbstractPostgreSQLTest {

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectTest.java
@@ -3,6 +3,7 @@ package jp.co.shimizutdev.phoneorderapi.infrastructure.log;
 import jp.co.shimizutdev.phoneorderapi.application.order.OrderService;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PagingCondition;
 import jp.co.shimizutdev.phoneorderapi.support.AbstractPostgreSQLTest;
+import jp.co.shimizutdev.phoneorderapi.support.ResetLogLevel;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,8 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * メソッド開始/終了ログ出力アスペクトテスト
  */
-@SpringBootTest
+@SpringBootTest(properties = "logging.level.jp.co.shimizutdev.phoneorderapi.infrastructure.log.MethodLogAspect=DEBUG")
 @ExtendWith(OutputCaptureExtension.class)
+@ResetLogLevel(MethodLogAspect.class)
 @SqlMergeMode(MergeMode.MERGE)
 @Sql(
     scripts = "classpath:sql/cleanup/cleanup-transaction-tables.sql",

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterTest.java
@@ -1,6 +1,7 @@
 package jp.co.shimizutdev.phoneorderapi.presentation.log;
 
 import jp.co.shimizutdev.phoneorderapi.support.AbstractPostgreSQLTest;
+import jp.co.shimizutdev.phoneorderapi.support.ResetLogLevel;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,11 +21,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * リクエスト/レスポンスのログを出力するフィルタテスト
  */
-@SpringBootTest
+@SpringBootTest(properties = "logging.level.jp.co.shimizutdev.phoneorderapi.presentation.log.RequestResponseLogFilter=DEBUG")
 @AutoConfigureMockMvc
 @ExtendWith(OutputCaptureExtension.class)
+@ResetLogLevel(RequestResponseLogFilter.class)
 class RequestResponseLogFilterTest extends AbstractPostgreSQLTest {
 
+    /**
+     * MockMvc
+     */
     @Autowired
     private MockMvc mockMvc;
 

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/support/ResetLogLevel.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/support/ResetLogLevel.java
@@ -1,0 +1,24 @@
+package jp.co.shimizutdev.phoneorderapi.support;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * テストクラスで変更したログレベルをテスト後に戻すアノテーション
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(ResetLogLevelExtension.class)
+public @interface ResetLogLevel {
+
+    /**
+     * ログレベルを戻すロガークラス
+     *
+     * @return ロガークラス
+     */
+    Class<?>[] value();
+}

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/support/ResetLogLevelExtension.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/support/ResetLogLevelExtension.java
@@ -1,0 +1,24 @@
+package jp.co.shimizutdev.phoneorderapi.support;
+
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.boot.logging.LoggingSystem;
+
+/**
+ * テストクラスで変更したログレベルをテスト後に戻す拡張
+ */
+public final class ResetLogLevelExtension implements AfterAllCallback {
+
+    @Override
+    public void afterAll(final ExtensionContext context) {
+        final ResetLogLevel resetLogLevel = context.getRequiredTestClass().getAnnotation(ResetLogLevel.class);
+        if (resetLogLevel == null) {
+            return;
+        }
+
+        final LoggingSystem loggingSystem = LoggingSystem.get(context.getRequiredTestClass().getClassLoader());
+        for (final Class<?> loggerClass : resetLogLevel.value()) {
+            loggingSystem.setLogLevel(loggerClass.getName(), null);
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,4 @@
+# suppress inspection "UnusedProperty" for whole file
 # ========================
 # Spring
 # ========================
@@ -19,5 +20,12 @@ spring.flyway.baseline-on-migrate=true
 # ========================
 # Logging
 # ========================
-logging.level.root=INFO
-logging.level.jp.co.shimizutdev.phoneorderapi=TRACE
+logging.level.root=WARN
+logging.level.jp.co.shimizutdev.phoneorderapi=WARN
+logging.level.jp.co.shimizutdev.phoneorderapi.infrastructure.log=OFF
+logging.level.jp.co.shimizutdev.phoneorderapi.presentation.log=OFF
+logging.level.org.testcontainers=WARN
+logging.level.org.springframework.test.context=WARN
+logging.level.org.springframework.boot.test.context=WARN
+logging.level.org.hibernate=WARN
+logging.level.org.flywaydb=WARN


### PR DESCRIPTION
## 概要

テスト実行時のログ出力を整理し、ログ検証用テストだけが必要なログを出せるようにしました。
あわせて、application.properties 系ファイルの `UnusedProperty` 警告をファイル単位で抑制しました。

## Issue

close #130

## 対応内容

- `src/test/resources/application.properties` のテスト用ログレベルを見直し、不要なログを抑制
- `OrderRepositoryTest` で SQL ログ出力を無効化
- `MethodLogAspectTest` と `RequestResponseLogFilterTest` で対象ロガーのみ DEBUG 出力するように変更
- テスト後に変更したログレベルを戻すための `@ResetLogLevel` と `ResetLogLevelExtension` を追加
- `src/main/resources/application.properties`、`src/main/resources/application-local.properties`、`src/test/resources/application.properties` の先頭に file-wide suppress コメントを追加し、`UnusedProperty` 警告を抑制

## 完了条件

実装担当者がチェック

- [x] テスト実行時の不要なログ出力が抑制されている
- [x] ログ出力を検証するテストだけが必要なログを出力できる
- [x] テスト内で変更したログレベルがテスト終了後にリセットされる
- [x] `application.properties` 系ファイルで `UnusedProperty` 警告が不要に表示されない

## レビュー観点

レビュー担当者がチェック

- [x] テスト全体のログレベル見直し内容が妥当か
- [x] ログ出力検証用テストで必要なログだけを有効化できているか
- [x] `ResetLogLevelExtension` によるログレベル復元方法に問題がないか
- [x] file-wide suppress の追加範囲が妥当で、不要な inspection まで隠していないか

## 備考（任意）

対象ファイル:
- `src/main/resources/application-local.properties`
- `src/main/resources/application.properties`
- `src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepositoryTest.java`
- `src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectTest.java`
- `src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterTest.java`
- `src/test/java/jp/co/shimizutdev/phoneorderapi/support/ResetLogLevel.java`
- `src/test/java/jp/co/shimizutdev/phoneorderapi/support/ResetLogLevelExtension.java`
- `src/test/resources/application.properties`