### PR TITLE
refactor: 運用時の安全性を高めるログ・Flyway設定の見直し (#132)

### DIFF
--- a/docs/09_development/intellij-local-profile-setup.md
+++ b/docs/09_development/intellij-local-profile-setup.md
@@ -64,7 +64,7 @@ PHONE_ORDER_DB_USERNAME=local;PHONE_ORDER_DB_PASSWORD=local
 ## 補足
 
 - `local` プロファイルを有効にすると、`application-local.properties` の設定が適用される。
-- ローカル用の datasource 設定や SQL 詳細ログ設定は `local` プロファイルで利用する。
+- ローカル用の datasource 設定、Flyway の `baseline-on-migrate`、SQL 詳細ログ設定は `local` プロファイルで利用する。
 - ローカル用 datasource の認証情報は `PHONE_ORDER_DB_USERNAME` / `PHONE_ORDER_DB_PASSWORD` で渡す。
 - `application.properties` には全環境共通の設定を置き、ローカル専用設定は `application-local.properties` に分離する。
 

--- a/docs/09_development/log-operation-rules.md
+++ b/docs/09_development/log-operation-rules.md
@@ -77,7 +77,10 @@ SQLログは Hibernate の logger 設定で制御する。
 
 ### ルール
 
-- `traceId` は自動採番とする
+- `X-Request-Id` が有効な traceId 形式の場合は `traceId` として引き継ぐ
+- `X-Request-Id` が無効で、`X-Correlation-Id` が有効な traceId 形式の場合は `X-Correlation-Id` を `traceId` として引き継ぐ
+- どちらのヘッダーも利用できない場合は `traceId` を自動採番する
+- 受け入れる `traceId` は 128 文字以内とし、英数字・`.`・`_`・`-` のみを許可する
 - アプリケーションコード側で手動採番しない
 - ログ出力時に `traceId` を必須項目とする
 - `traceId` を業務項目の代わりに使わない
@@ -220,6 +223,8 @@ logging.level.jp.co.shimizutdev.phoneorderapi=INFO
 - 非対応 Content-Type は `[unsupported content type]` として扱う
 - body は 1 行化して出力する
 - body は最大文字数で切り詰める
+- body の文字エンコーディングが未指定または不正な場合は UTF-8 として扱う
+- body のログ変換失敗でレスポンス返却を妨げない
 - レスポンス body を壊さないよう `ContentCachingResponseWrapper` を使用する
 
 ---

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilter.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilter.java
@@ -16,7 +16,9 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.Collectors;
@@ -300,7 +302,12 @@ public class RequestResponseLogFilter extends OncePerRequestFilter {
         if (encoding == null || encoding.isBlank()) {
             return StandardCharsets.UTF_8;
         }
-        return Charset.forName(encoding);
+
+        try {
+            return Charset.forName(encoding);
+        } catch (IllegalCharsetNameException | UnsupportedCharsetException ex) {
+            return StandardCharsets.UTF_8;
+        }
     }
 
     /**

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilter.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilter.java
@@ -13,6 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * トレースIDをMDCへ設定するFilter
@@ -41,6 +42,16 @@ public class TraceIdFilter extends OncePerRequestFilter {
      * レスポンスへ traceId を返却するためのヘッダー名
      */
     private static final String TRACE_ID_HEADER = "X-Trace-Id";
+
+    /**
+     * 受け入れる traceId の最大文字数
+     */
+    private static final int TRACE_ID_MAX_LENGTH = 128;
+
+    /**
+     * 受け入れる traceId の文字種パターン
+     */
+    private static final Pattern TRACE_ID_PATTERN = Pattern.compile("^[A-Za-z0-9._-]+$");
 
     /**
      * トレースIDを設定してフィルタチェーンを実行する
@@ -77,15 +88,33 @@ public class TraceIdFilter extends OncePerRequestFilter {
     private String resolveTraceId(final HttpServletRequest request) {
         String requestId = request.getHeader(REQUEST_ID_HEADER);
 
-        if (requestId != null && !requestId.isBlank()) {
+        if (isValidTraceId(requestId)) {
             return requestId.trim();
         }
 
         String correlationId = request.getHeader(CORRELATION_ID_HEADER);
-        if (correlationId != null && !correlationId.isBlank()) {
+        if (isValidTraceId(correlationId)) {
             return correlationId.trim();
         }
 
         return UUID.randomUUID().toString();
+    }
+
+    /**
+     * 指定された traceId が受け入れ可能かを検証する
+     *
+     * @param traceId 検証対象の traceId
+     * @return traceId が空でなく、長さ制限内で、許可パターンに一致する場合は {@code true}
+     */
+    private boolean isValidTraceId(final String traceId) {
+        if (traceId == null) {
+            return false;
+        }
+
+        String normalizedTraceId = traceId.trim();
+
+        return !normalizedTraceId.isEmpty()
+            && normalizedTraceId.length() <= TRACE_ID_MAX_LENGTH
+            && TRACE_ID_PATTERN.matcher(normalizedTraceId).matches();
     }
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -7,6 +7,10 @@ spring.datasource.username=${PHONE_ORDER_DB_USERNAME}
 spring.datasource.password=${PHONE_ORDER_DB_PASSWORD}
 spring.datasource.driver-class-name=org.postgresql.Driver
 # ========================
+# Flyway
+# ========================
+spring.flyway.baseline-on-migrate=true
+# ========================
 # SQL
 # ========================
 logging.level.org.hibernate.SQL=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,7 +16,6 @@ spring.jpa.properties.hibernate.format_sql=false
 # ========================
 spring.flyway.enabled=true
 spring.flyway.locations=classpath:db/migration
-spring.flyway.baseline-on-migrate=true
 # ========================
 # Logging
 # ========================

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterTest.java
@@ -1,5 +1,9 @@
 package jp.co.shimizutdev.phoneorderapi.presentation.log;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletResponse;
+import jp.co.shimizutdev.phoneorderapi.infrastructure.log.LogMasker;
 import jp.co.shimizutdev.phoneorderapi.support.AbstractPostgreSQLTest;
 import jp.co.shimizutdev.phoneorderapi.support.ResetLogLevel;
 import org.junit.jupiter.api.DisplayName;
@@ -12,9 +16,13 @@ import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -81,5 +89,38 @@ class RequestResponseLogFilterTest extends AbstractPostgreSQLTest {
             .contains("\"path\":\"/api/v1/orders\"")
             .contains("\"validationErrors\":[]")
             .contains("[response] size(bytes):");
+    }
+
+    /**
+     * <pre>
+     * Given 不正な文字エンコーディングを持つJSONリクエストを用意する
+     * When リクエスト/レスポンスログフィルタを実行する
+     * Then UTF-8へフォールバックしてレスポンスが返却される
+     * </pre>
+     */
+    @Test
+    @DisplayName("不正な文字エンコーディングでもUTF-8へフォールバックできること")
+    void shouldFallbackToUtf8WhenRequestEncodingIsInvalid() throws Exception {
+        RequestResponseLogFilter filter = new RequestResponseLogFilter(new LogMasker(new ObjectMapper()));
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.setMethod("POST");
+        request.setRequestURI("/test");
+        request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        request.setCharacterEncoding("invalid-charset");
+        request.setContent("""
+            {"password":"secret-password"}
+            """.getBytes());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+        FilterChain filterChain = (req, res) -> {
+            HttpServletResponse actualResponse = (HttpServletResponse) res;
+            actualResponse.setStatus(200);
+            actualResponse.getWriter().write("{\"status\":\"ok\"}");
+        };
+
+        assertDoesNotThrow(() -> filter.doFilter(request, response, filterChain));
+        assertEquals(200, response.getStatus());
+        assertThat(response.getContentAsString()).contains("\"status\":\"ok\"");
     }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilterTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilterTest.java
@@ -74,6 +74,53 @@ class TraceIdFilterTest {
 
     /**
      * <pre>
+     * Given 不正な X-Request-Id と有効な X-Correlation-Id を含むリクエストを用意する
+     * When フィルタを実行する
+     * Then X-Correlation-Id が traceId として設定される
+     * </pre>
+     */
+    @Test
+    @DisplayName("不正な X-Request-Id の場合は X-Correlation-Id を traceId として引き継ぐこと")
+    void shouldFallbackToCorrelationIdWhenRequestIdIsInvalid() {
+        TraceIdFilter traceIdFilter = new TraceIdFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("X-Request-Id", "invalid trace id");
+        request.addHeader("X-Correlation-Id", "correlation-123");
+        AtomicReference<String> actualTraceId = new AtomicReference<>();
+        FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
+
+        assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
+
+        assertEquals("correlation-123", actualTraceId.get());
+        assertEquals("correlation-123", response.getHeader("X-Trace-Id"));
+    }
+
+    /**
+     * <pre>
+     * Given 不正な X-Request-Id を含むリクエストを用意する
+     * When フィルタを実行する
+     * Then UUID形式の traceId が新規生成される
+     * </pre>
+     */
+    @Test
+    @DisplayName("不正なヘッダーの場合はUUID形式の traceId を生成すること")
+    void shouldGenerateTraceIdWhenHeadersAreInvalid() {
+        TraceIdFilter traceIdFilter = new TraceIdFilter();
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader("X-Request-Id", "a".repeat(129));
+        AtomicReference<String> actualTraceId = new AtomicReference<>();
+        FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
+
+        assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
+
+        assertTrue(isUuid(actualTraceId.get()));
+        assertEquals(actualTraceId.get(), response.getHeader("X-Trace-Id"));
+    }
+
+    /**
+     * <pre>
      * Given トレースIDフィルタを用意する
      * When フィルタを実行する
      * Then フィルタチェーン実行後にMDCからトレースIDが削除される


### PR DESCRIPTION

## 概要

ログ処理と Flyway 設定に関する運用リスクを低減する

## Issue

close #132

## 対応内容

- TraceIdFilter で受け入れる traceId の長さと文字種を検証する
- 無効な X-Request-Id の場合は X-Correlation-Id、どちらも無効な場合は UUID を利用する
- RequestResponseLogFilter で不正な文字エンコーディング指定時に UTF-8 へフォールバックする
- spring.flyway.baseline-on-migrate を local プロファイル専用へ移動する
- traceId 検証と文字エンコーディングフォールバックの回帰テストを追加する

## 完了条件

実装担当者がチェック

- [x] 不正な traceId が MDC とレスポンスヘッダーへそのまま反映されないこと
- [x] 不正な文字エンコーディング指定でもログ処理でレスポンス返却が妨げられないこと
- [x] Flyway の baseline-on-migrate がデフォルト設定では有効にならないこと
- [x] 関連するテストが成功すること

## レビュー観点

レビュー担当者がチェック

- [x] traceId の許可文字・最大長が運用上妥当であること
- [x] 不正な charset のフォールバックがログ用途に閉じており、レスポンス処理へ副作用を与えないこと
- [x] baseline-on-migrate が local プロファイルに限定されていること
- [x] 追加テストが今回の不具合再発防止として十分であること

## 備考（任意）

確認コマンド:

`./mvnw test "-Dtest=TraceIdFilterTest,RequestResponseLogFilterTest"`