### PR TITLE
refactor: 品質運用の自動化として整形・依存ルール検査・CI 検証を追加する (#138)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run tests
         env:
           TESTCONTAINERS_HOST_OVERRIDE: host.docker.internal
-        run: sh ./mvnw -B -Dmaven.repo.local="$HOME/.m2/repository" test
+        run: sh ./mvnw -B -Dmaven.repo.local="$HOME/.m2/repository" spotless:check test
 
       - name: Verify tracked files are unchanged after build
         run: |

--- a/README.md
+++ b/README.md
@@ -171,7 +171,25 @@ IntelliJ IDEA から起動する場合の環境変数設定手順は
 ```
 
 `generate-sources` フェーズで OpenAPI Generator が実行され、API インターフェースと API 入出力モデルが生成されます。
-GitHub Actions では Debian Trixie Slim コンテナ上で `sh ./mvnw test` を実行し、tracked file がビルド後に変化しないことも検証します。
+GitHub Actions では Debian Trixie Slim コンテナ上で `sh ./mvnw spotless:check test` を実行し、tracked file がビルド後に変化しないことも検証します。
+
+品質チェック付きの確認例:
+
+```bash
+./mvnw spotless:check test
+```
+
+このコマンドでは以下をまとめて確認します。
+
+- Spotless による Java 整形ルール
+- Maven Enforcer による Java / Maven バージョンと依存定義
+- 単体テストと ArchUnit による依存ルール検証
+
+Java 整形を反映する場合:
+
+```bash
+./mvnw spotless:apply
+```
 
 ---
 

--- a/docs/09_development/development-flow.md
+++ b/docs/09_development/development-flow.md
@@ -191,6 +191,10 @@ git checkout -b feature/12
 - 実装
 - 動作確認
 - テスト
+- `./mvnw spotless:check test` による品質チェック
+  - Spotless による Java 整形ルール確認
+  - Maven Enforcer による Java / Maven バージョンと依存定義確認
+  - 単体テストと ArchUnit による依存ルール確認
 
 以下を参照
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,11 @@
 
   <properties>
     <java.version>21</java.version>
+    <maven.version>3.9.0</maven.version>
+    <archunit.version>1.4.1</archunit.version>
+    <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
+    <maven-enforcer-plugin.version>3.6.1</maven-enforcer-plugin.version>
+    <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
     <tomcat.version>10.1.54</tomcat.version>
     <openapi-generator.version>7.21.0</openapi-generator.version>
   </properties>
@@ -116,10 +121,42 @@
       <artifactId>postgresql</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.tngtech.archunit</groupId>
+      <artifactId>archunit-junit5</artifactId>
+      <version>${archunit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <version>${maven-enforcer-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>enforce-build-environment</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>${java.version}</version>
+                </requireJavaVersion>
+                <requireMavenVersion>
+                  <version>${maven.version}</version>
+                </requireMavenVersion>
+                <banDuplicatePomDependencyVersions/>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -182,12 +219,56 @@
       </plugin>
 
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>add-openapi-generated-sources</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/openapi/src/main/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
             -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
           </argLine>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>${spotless-maven-plugin.version}</version>
+        <configuration>
+          <java>
+            <includes>
+              <include>src/main/java/**/*.java</include>
+              <include>src/test/java/**/*.java</include>
+            </includes>
+            <googleJavaFormat>
+              <version>1.24.0</version>
+              <style>GOOGLE</style>
+              <reflowLongStrings>true</reflowLongStrings>
+              <formatJavadoc>true</formatJavadoc>
+            </googleJavaFormat>
+            <removeUnusedImports/>
+            <formatAnnotations/>
+            <trimTrailingWhitespace/>
+            <endWithNewline/>
+          </java>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/PhoneOrderApiApplication.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/PhoneOrderApiApplication.java
@@ -4,19 +4,17 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-/**
- * アプリケーション起動クラス
- */
+/** アプリケーション起動クラス */
 @SpringBootApplication
 @EnableJpaAuditing(auditorAwareRef = "auditorAware")
 public class PhoneOrderApiApplication {
 
-    /**
-     * アプリケーションを起動する
-     *
-     * @param args 起動引数
-     */
-    public static void main(final String[] args) {
-        SpringApplication.run(PhoneOrderApiApplication.class, args);
-    }
+  /**
+   * アプリケーションを起動する
+   *
+   * @param args 起動引数
+   */
+  public static void main(final String[] args) {
+    SpringApplication.run(PhoneOrderApiApplication.class, args);
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderService.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderService.java
@@ -1,5 +1,6 @@
 package jp.co.shimizutdev.phoneorderapi.application.order;
 
+import java.util.Objects;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PageResult;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PagingCondition;
 import jp.co.shimizutdev.phoneorderapi.domain.order.*;
@@ -7,92 +8,85 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
-
-/**
- * 注文サービス
- */
+/** 注文サービス */
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OrderService {
 
-    /**
-     * 注文リポジトリ
-     */
-    private final OrderRepository orderRepository;
+  /** 注文リポジトリ */
+  private final OrderRepository orderRepository;
 
-    /**
-     * 注文コード採番
-     */
-    private final OrderCodeGenerator orderCodeGenerator;
+  /** 注文コード採番 */
+  private final OrderCodeGenerator orderCodeGenerator;
 
-    /**
-     * 注文一覧を取得する
-     *
-     * @param pagingCondition ページング条件
-     * @return 注文日時降順、同一日時は注文コード降順のページング済み注文一覧。存在しない場合または範囲外ページの場合は空のページ
-     * @throws NullPointerException ページング条件が null の場合
-     */
-    public PageResult<Order> getOrders(final PagingCondition pagingCondition) {
-        return orderRepository.findAll(Objects.requireNonNull(pagingCondition, "ページング条件は必須です。"));
-    }
+  /**
+   * 注文一覧を取得する
+   *
+   * @param pagingCondition ページング条件
+   * @return 注文日時降順、同一日時は注文コード降順のページング済み注文一覧。存在しない場合または範囲外ページの場合は空のページ
+   * @throws NullPointerException ページング条件が null の場合
+   */
+  public PageResult<Order> getOrders(final PagingCondition pagingCondition) {
+    return orderRepository.findAll(Objects.requireNonNull(pagingCondition, "ページング条件は必須です。"));
+  }
 
-    /**
-     * 注文コードで注文を取得する
-     *
-     * @param orderCode 注文コード
-     * @return 注文
-     * @throws NullPointerException 注文コードが null の場合
-     * @throws OrderNotFoundException 注文コードに対応する注文が存在しない場合
-     */
-    public Order getOrderByOrderCode(final OrderCode orderCode) {
-        return findOrderByOrderCode(orderCode);
-    }
+  /**
+   * 注文コードで注文を取得する
+   *
+   * @param orderCode 注文コード
+   * @return 注文
+   * @throws NullPointerException 注文コードが null の場合
+   * @throws OrderNotFoundException 注文コードに対応する注文が存在しない場合
+   */
+  public Order getOrderByOrderCode(final OrderCode orderCode) {
+    return findOrderByOrderCode(orderCode);
+  }
 
-    /**
-     * 注文を登録する
-     *
-     * @param orderedAt 注文日時
-     * @return 注文
-     * @throws NullPointerException 注文日時が null の場合
-     */
-    @Transactional
-    public Order createOrder(final OrderedAt orderedAt) {
-        OrderCode orderCode = orderCodeGenerator.generate();
-        Order order = Order.create(orderCode, Objects.requireNonNull(orderedAt, "注文日時は必須です。"));
-        return orderRepository.create(order);
-    }
+  /**
+   * 注文を登録する
+   *
+   * @param orderedAt 注文日時
+   * @return 注文
+   * @throws NullPointerException 注文日時が null の場合
+   */
+  @Transactional
+  public Order createOrder(final OrderedAt orderedAt) {
+    OrderCode orderCode = orderCodeGenerator.generate();
+    Order order = Order.create(orderCode, Objects.requireNonNull(orderedAt, "注文日時は必須です。"));
+    return orderRepository.create(order);
+  }
 
-    /**
-     * 注文をキャンセルする
-     *
-     * @param orderCode 注文コード
-     * @param version   キャンセル要求時の注文バージョン
-     * @return 注文
-     * @throws NullPointerException 注文コードまたはバージョンが null の場合
-     * @throws OrderNotFoundException 注文コードに対応する注文が存在しない場合
-     * @throws OrderCannotBeCancelledException 注文の状態によりキャンセルできない場合
-     * @throws OrderVersionConflictException 注文のバージョンが一致しない場合
-     */
-    @Transactional
-    public Order cancelOrder(final OrderCode orderCode, final Version version) {
-        Order order = findOrderByOrderCode(orderCode);
+  /**
+   * 注文をキャンセルする
+   *
+   * @param orderCode 注文コード
+   * @param version キャンセル要求時の注文バージョン
+   * @return 注文
+   * @throws NullPointerException 注文コードまたはバージョンが null の場合
+   * @throws OrderNotFoundException 注文コードに対応する注文が存在しない場合
+   * @throws OrderCannotBeCancelledException 注文の状態によりキャンセルできない場合
+   * @throws OrderVersionConflictException 注文のバージョンが一致しない場合
+   */
+  @Transactional
+  public Order cancelOrder(final OrderCode orderCode, final Version version) {
+    Order order = findOrderByOrderCode(orderCode);
 
-        return orderRepository.update(order.cancel(Objects.requireNonNull(version, "バージョンは必須です。")));
-    }
+    return orderRepository.update(order.cancel(Objects.requireNonNull(version, "バージョンは必須です。")));
+  }
 
-    /**
-     * 注文コードで注文を取得し、存在しない場合は注文未存在例外を発生させる
-     *
-     * @param orderCode 注文コード
-     * @return 注文
-     * @throws NullPointerException 注文コードが null の場合
-     * @throws OrderNotFoundException   注文コードに対応する注文が存在しない場合
-     */
-    private Order findOrderByOrderCode(final OrderCode orderCode) {
-        OrderCode validOrderCode = Objects.requireNonNull(orderCode, "注文コードは必須です。");
-        return orderRepository.findByOrderCode(validOrderCode)
-            .orElseThrow(() -> OrderNotFoundException.byOrderCode(validOrderCode.getValue()));
-    }
+  /**
+   * 注文コードで注文を取得し、存在しない場合は注文未存在例外を発生させる
+   *
+   * @param orderCode 注文コード
+   * @return 注文
+   * @throws NullPointerException 注文コードが null の場合
+   * @throws OrderNotFoundException 注文コードに対応する注文が存在しない場合
+   */
+  private Order findOrderByOrderCode(final OrderCode orderCode) {
+    OrderCode validOrderCode = Objects.requireNonNull(orderCode, "注文コードは必須です。");
+    return orderRepository
+        .findByOrderCode(validOrderCode)
+        .orElseThrow(() -> OrderNotFoundException.byOrderCode(validOrderCode.getValue()));
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/common/PageResult.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/common/PageResult.java
@@ -6,73 +6,66 @@ import java.util.Objects;
 /**
  * ページング済みの検索結果
  *
- * @param items         取得した要素一覧
- * @param page          取得ページ番号。0 始まり
- * @param size          1 ページあたりの取得件数。1 以上 100 以下
+ * @param items 取得した要素一覧
+ * @param page 取得ページ番号。0 始まり
+ * @param size 1 ページあたりの取得件数。1 以上 100 以下
  * @param totalElements 条件に一致する総件数
- * @param totalPages    総件数とページサイズから算出した総ページ数
- * @param <T>           要素型
+ * @param totalPages 総件数とページサイズから算出した総ページ数
+ * @param <T> 要素型
  */
-public record PageResult<T>(
-    List<T> items,
-    int page,
-    int size,
-    long totalElements,
-    int totalPages
-) {
+public record PageResult<T>(List<T> items, int page, int size, long totalElements, int totalPages) {
 
-    /**
-     * ページング済みの検索結果を生成する
-     *
-     * <p>要素一覧は防御的コピーされ、不変リストとして保持される</p>
-     * <p>要素数はページサイズ以下、総ページ数は総件数とページサイズから算出される値と一致する必要がある</p>
-     *
-     * @throws NullPointerException     要素一覧が null の場合
-     * @throws IllegalArgumentException ページ番号、ページサイズ、総件数、総ページ数、要素数が不正な場合
-     */
-    public PageResult {
-        items = List.copyOf(Objects.requireNonNull(items, "要素一覧は必須です。"));
-        if (page < 0) {
-            throw new IllegalArgumentException("ページ番号は0以上である必要があります。");
-        }
-        if (size < 1) {
-            throw new IllegalArgumentException("ページサイズは1以上である必要があります。");
-        }
-        if (size > PagingCondition.MAX_SIZE) {
-            throw new IllegalArgumentException("ページサイズは" + PagingCondition.MAX_SIZE + "以下である必要があります。");
-        }
-        if (totalElements < 0) {
-            throw new IllegalArgumentException("総件数は0以上である必要があります。");
-        }
-        if (totalPages < 0) {
-            throw new IllegalArgumentException("総ページ数は0以上である必要があります。");
-        }
-        if (items.size() > size) {
-            throw new IllegalArgumentException("要素数はページサイズ以下である必要があります。");
-        }
-        long calculatedTotalPages = totalElements == 0L
-            ? 0L
-            : ((totalElements - 1L) / size) + 1L;
-        if (totalPages != calculatedTotalPages) {
-            throw new IllegalArgumentException("総ページ数は総件数とページサイズから算出される値と一致する必要があります。");
-        }
+  /**
+   * ページング済みの検索結果を生成する
+   *
+   * <p>要素一覧は防御的コピーされ、不変リストとして保持される
+   *
+   * <p>要素数はページサイズ以下、総ページ数は総件数とページサイズから算出される値と一致する必要がある
+   *
+   * @throws NullPointerException 要素一覧が null の場合
+   * @throws IllegalArgumentException ページ番号、ページサイズ、総件数、総ページ数、要素数が不正な場合
+   */
+  public PageResult {
+    items = List.copyOf(Objects.requireNonNull(items, "要素一覧は必須です。"));
+    if (page < 0) {
+      throw new IllegalArgumentException("ページ番号は0以上である必要があります。");
     }
+    if (size < 1) {
+      throw new IllegalArgumentException("ページサイズは1以上である必要があります。");
+    }
+    if (size > PagingCondition.MAX_SIZE) {
+      throw new IllegalArgumentException("ページサイズは" + PagingCondition.MAX_SIZE + "以下である必要があります。");
+    }
+    if (totalElements < 0) {
+      throw new IllegalArgumentException("総件数は0以上である必要があります。");
+    }
+    if (totalPages < 0) {
+      throw new IllegalArgumentException("総ページ数は0以上である必要があります。");
+    }
+    if (items.size() > size) {
+      throw new IllegalArgumentException("要素数はページサイズ以下である必要があります。");
+    }
+    long calculatedTotalPages = totalElements == 0L ? 0L : ((totalElements - 1L) / size) + 1L;
+    if (totalPages != calculatedTotalPages) {
+      throw new IllegalArgumentException("総ページ数は総件数とページサイズから算出される値と一致する必要があります。");
+    }
+  }
 
-    /**
-     * 次ページが存在するか判定する
-     *
-     * @return 次ページが存在する場合 true
-     */
-    public boolean hasNext() {
-        return page + 1 < totalPages;
-    }
+  /**
+   * 次ページが存在するか判定する
+   *
+   * @return 次ページが存在する場合 true
+   */
+  public boolean hasNext() {
+    return page + 1 < totalPages;
+  }
 
-    /**
-     * 前ページが存在するか判定する
-     *
-     * @return 前ページが存在する場合 true
-     */
-    public boolean hasPrevious() {
-        return page > 0;
-    }
+  /**
+   * 前ページが存在するか判定する
+   *
+   * @return 前ページが存在する場合 true
+   */
+  public boolean hasPrevious() {
+    return page > 0;
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/common/PagingCondition.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/common/PagingCondition.java
@@ -8,64 +8,56 @@ package jp.co.shimizutdev.phoneorderapi.domain.common;
  */
 public record PagingCondition(int page, int size) {
 
-    /**
-     * デフォルトページ番号
-     */
-    public static final int DEFAULT_PAGE = 0;
+  /** デフォルトページ番号 */
+  public static final int DEFAULT_PAGE = 0;
 
-    /**
-     * デフォルトページサイズ
-     */
-    public static final int DEFAULT_SIZE = 20;
+  /** デフォルトページサイズ */
+  public static final int DEFAULT_SIZE = 20;
 
-    /**
-     * 最大ページサイズ
-     */
-    public static final int MAX_SIZE = 100;
+  /** 最大ページサイズ */
+  public static final int MAX_SIZE = 100;
 
-    /**
-     * ページング条件を生成する
-     *
-     * <p>ページ番号は 0 以上、ページサイズは 1 以上 100 以下である必要がある</p>
-     *
-     * @throws IllegalArgumentException ページ番号またはページサイズが不正な場合
-     */
-    public PagingCondition {
-        if (page < 0) {
-            throw new IllegalArgumentException("ページ番号は0以上である必要があります。");
-        }
-        if (size < 1) {
-            throw new IllegalArgumentException("ページサイズは1以上である必要があります。");
-        }
-        if (size > MAX_SIZE) {
-            throw new IllegalArgumentException("ページサイズは" + MAX_SIZE + "以下である必要があります。");
-        }
+  /**
+   * ページング条件を生成する
+   *
+   * <p>ページ番号は 0 以上、ページサイズは 1 以上 100 以下である必要がある
+   *
+   * @throws IllegalArgumentException ページ番号またはページサイズが不正な場合
+   */
+  public PagingCondition {
+    if (page < 0) {
+      throw new IllegalArgumentException("ページ番号は0以上である必要があります。");
     }
-
-    /**
-     * ページング条件を生成する
-     *
-     * @param page 取得ページ番号。0 始まり
-     * @param size 1 ページあたりの取得件数。1 以上 100 以下
-     * @return ページング条件
-     * @throws IllegalArgumentException ページ番号またはページサイズが不正な場合
-     */
-    public static PagingCondition of(final int page, final int size) {
-        return new PagingCondition(page, size);
+    if (size < 1) {
+      throw new IllegalArgumentException("ページサイズは1以上である必要があります。");
     }
-
-    /**
-     * 未指定値をデフォルト値で補完してページング条件を生成する
-     *
-     * @param page 取得ページ番号。null の場合はデフォルトページ番号
-     * @param size 1 ページあたりの取得件数。null の場合はデフォルトページサイズ
-     * @return ページング条件
-     * @throws IllegalArgumentException ページ番号またはページサイズが不正な場合
-     */
-    public static PagingCondition ofNullable(final Integer page, final Integer size) {
-        return new PagingCondition(
-            page == null ? DEFAULT_PAGE : page,
-            size == null ? DEFAULT_SIZE : size
-        );
+    if (size > MAX_SIZE) {
+      throw new IllegalArgumentException("ページサイズは" + MAX_SIZE + "以下である必要があります。");
     }
+  }
+
+  /**
+   * ページング条件を生成する
+   *
+   * @param page 取得ページ番号。0 始まり
+   * @param size 1 ページあたりの取得件数。1 以上 100 以下
+   * @return ページング条件
+   * @throws IllegalArgumentException ページ番号またはページサイズが不正な場合
+   */
+  public static PagingCondition of(final int page, final int size) {
+    return new PagingCondition(page, size);
+  }
+
+  /**
+   * 未指定値をデフォルト値で補完してページング条件を生成する
+   *
+   * @param page 取得ページ番号。null の場合はデフォルトページ番号
+   * @param size 1 ページあたりの取得件数。null の場合はデフォルトページサイズ
+   * @return ページング条件
+   * @throws IllegalArgumentException ページ番号またはページサイズが不正な場合
+   */
+  public static PagingCondition ofNullable(final Integer page, final Integer size) {
+    return new PagingCondition(
+        page == null ? DEFAULT_PAGE : page, size == null ? DEFAULT_SIZE : size);
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/Order.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/Order.java
@@ -1,143 +1,111 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
+import java.util.Objects;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.Objects;
-
-/**
- * 注文
- */
+/** 注文 */
 @Getter
 @ToString
 @EqualsAndHashCode
 public class Order {
 
-    /**
-     * 注文ID
-     */
-    private final OrderId orderId;
+  /** 注文ID */
+  private final OrderId orderId;
 
-    /**
-     * 注文コード
-     */
-    private final OrderCode orderCode;
+  /** 注文コード */
+  private final OrderCode orderCode;
 
-    /**
-     * 注文日時
-     */
-    private final OrderedAt orderedAt;
+  /** 注文日時 */
+  private final OrderedAt orderedAt;
 
-    /**
-     * 注文ステータス
-     */
-    private final OrderStatus orderStatus;
+  /** 注文ステータス */
+  private final OrderStatus orderStatus;
 
-    /**
-     * バージョン
-     */
-    private final Version version;
+  /** バージョン */
+  private final Version version;
 
-    /**
-     * コンストラクタ
-     *
-     * @param orderId     注文ID
-     * @param orderCode   注文コード
-     * @param orderedAt   注文日時
-     * @param orderStatus 注文ステータス
-     * @param version     バージョン
-     */
-    private Order(
-        final OrderId orderId,
-        final OrderCode orderCode,
-        final OrderedAt orderedAt,
-        final OrderStatus orderStatus,
-        final Version version) {
-        this.orderId = Objects.requireNonNull(orderId, "注文IDは必須です。");
-        this.orderCode = Objects.requireNonNull(orderCode, "注文コードは必須です。");
-        this.orderedAt = Objects.requireNonNull(orderedAt, "注文日時は必須です。");
-        this.orderStatus = Objects.requireNonNull(orderStatus, "注文ステータスは必須です。");
-        this.version = Objects.requireNonNull(version, "バージョンは必須です。");
+  /**
+   * コンストラクタ
+   *
+   * @param orderId 注文ID
+   * @param orderCode 注文コード
+   * @param orderedAt 注文日時
+   * @param orderStatus 注文ステータス
+   * @param version バージョン
+   */
+  private Order(
+      final OrderId orderId,
+      final OrderCode orderCode,
+      final OrderedAt orderedAt,
+      final OrderStatus orderStatus,
+      final Version version) {
+    this.orderId = Objects.requireNonNull(orderId, "注文IDは必須です。");
+    this.orderCode = Objects.requireNonNull(orderCode, "注文コードは必須です。");
+    this.orderedAt = Objects.requireNonNull(orderedAt, "注文日時は必須です。");
+    this.orderStatus = Objects.requireNonNull(orderStatus, "注文ステータスは必須です。");
+    this.version = Objects.requireNonNull(version, "バージョンは必須です。");
+  }
+
+  /**
+   * 注文を生成する
+   *
+   * @param orderCode 注文コード
+   * @param orderedAt 注文日時
+   * @return 注文
+   */
+  public static Order create(final OrderCode orderCode, final OrderedAt orderedAt) {
+    return new Order(
+        OrderId.generate(), orderCode, orderedAt, OrderStatus.RECEIVED, Version.of(0L));
+  }
+
+  /**
+   * 注文を再構築する
+   *
+   * @param orderId 注文ID
+   * @param orderCode 注文コード
+   * @param orderedAt 注文日時
+   * @param orderStatus 注文ステータス
+   * @param version バージョン
+   * @return 注文
+   */
+  public static Order reconstruct(
+      final OrderId orderId,
+      final OrderCode orderCode,
+      final OrderedAt orderedAt,
+      final OrderStatus orderStatus,
+      final Version version) {
+    return new Order(orderId, orderCode, orderedAt, orderStatus, version);
+  }
+
+  /**
+   * 注文をキャンセルする
+   *
+   * @param requestedVersion 要求されたバージョン
+   * @return キャンセル済み注文
+   * @throws OrderVersionConflictException 要求されたバージョンと現在のバージョンが一致しない場合
+   * @throws OrderCannotBeCancelledException 注文の状態によりキャンセルできない場合
+   */
+  public Order cancel(final Version requestedVersion) {
+    validateVersionMatch(requestedVersion);
+
+    if (orderStatus == OrderStatus.COMPLETED || orderStatus == OrderStatus.CANCELLED) {
+      throw OrderCannotBeCancelledException.byOrder(this);
     }
 
-    /**
-     * 注文を生成する
-     *
-     * @param orderCode 注文コード
-     * @param orderedAt 注文日時
-     * @return 注文
-     */
-    public static Order create(
-        final OrderCode orderCode,
-        final OrderedAt orderedAt) {
-        return new Order(
-            OrderId.generate(),
-            orderCode,
-            orderedAt,
-            OrderStatus.RECEIVED,
-            Version.of(0L)
-        );
+    return new Order(orderId, orderCode, orderedAt, OrderStatus.CANCELLED, version);
+  }
+
+  /**
+   * バージョン一致を検証する
+   *
+   * @param requestedVersion 要求されたバージョン
+   * @throws OrderVersionConflictException 要求されたバージョンと現在のバージョンが一致しない場合
+   */
+  private void validateVersionMatch(final Version requestedVersion) {
+    if (!version.equals(requestedVersion)) {
+      throw OrderVersionConflictException.byOrder(this, requestedVersion);
     }
-
-    /**
-     * 注文を再構築する
-     *
-     * @param orderId     注文ID
-     * @param orderCode   注文コード
-     * @param orderedAt   注文日時
-     * @param orderStatus 注文ステータス
-     * @param version     バージョン
-     * @return 注文
-     */
-    public static Order reconstruct(
-        final OrderId orderId,
-        final OrderCode orderCode,
-        final OrderedAt orderedAt,
-        final OrderStatus orderStatus,
-        final Version version) {
-        return new Order(
-            orderId,
-            orderCode,
-            orderedAt,
-            orderStatus,
-            version
-        );
-    }
-
-    /**
-     * 注文をキャンセルする
-     *
-     * @param requestedVersion 要求されたバージョン
-     * @return キャンセル済み注文
-     * @throws OrderVersionConflictException 要求されたバージョンと現在のバージョンが一致しない場合
-     * @throws OrderCannotBeCancelledException 注文の状態によりキャンセルできない場合
-     */
-    public Order cancel(final Version requestedVersion) {
-        validateVersionMatch(requestedVersion);
-
-        if (orderStatus == OrderStatus.COMPLETED || orderStatus == OrderStatus.CANCELLED) {
-            throw OrderCannotBeCancelledException.byOrder(this);
-        }
-
-        return new Order(
-            orderId,
-            orderCode,
-            orderedAt,
-            OrderStatus.CANCELLED,
-            version
-        );
-    }
-
-    /**
-     * バージョン一致を検証する
-     *
-     * @param requestedVersion 要求されたバージョン
-     * @throws OrderVersionConflictException 要求されたバージョンと現在のバージョンが一致しない場合
-     */
-    private void validateVersionMatch(final Version requestedVersion) {
-        if (!version.equals(requestedVersion)) {
-            throw OrderVersionConflictException.byOrder(this, requestedVersion);
-        }
-    }
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderCannotBeCancelledException.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderCannotBeCancelledException.java
@@ -1,38 +1,32 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
-/**
- * 注文キャンセル不可例外
- */
+/** 注文キャンセル不可例外 */
 public class OrderCannotBeCancelledException extends RuntimeException {
 
-    /**
-     * 注文キャンセル不可時のログ用メッセージテンプレート
-     */
-    private static final String MESSAGE_TEMPLATE =
-        "注文をキャンセルできません: orderId=%s, orderCode=%s, status=%s";
+  /** 注文キャンセル不可時のログ用メッセージテンプレート */
+  private static final String MESSAGE_TEMPLATE =
+      "注文をキャンセルできません: orderId=%s, orderCode=%s, status=%s";
 
-    /**
-     * コンストラクタ
-     *
-     * @param message 例外メッセージ
-     */
-    private OrderCannotBeCancelledException(final String message) {
-        super(message);
-    }
+  /**
+   * コンストラクタ
+   *
+   * @param message 例外メッセージ
+   */
+  private OrderCannotBeCancelledException(final String message) {
+    super(message);
+  }
 
-    /**
-     * 注文の状態によりキャンセルできない場合の例外を生成する
-     *
-     * @param order キャンセルできない注文
-     * @return 注文キャンセル不可例外
-     */
-    public static OrderCannotBeCancelledException byOrder(final Order order) {
-        return new OrderCannotBeCancelledException(
-            MESSAGE_TEMPLATE.formatted(
-                order.getOrderId().getValue(),
-                order.getOrderCode().getValue(),
-                order.getOrderStatus().name()
-            )
-        );
-    }
+  /**
+   * 注文の状態によりキャンセルできない場合の例外を生成する
+   *
+   * @param order キャンセルできない注文
+   * @return 注文キャンセル不可例外
+   */
+  public static OrderCannotBeCancelledException byOrder(final Order order) {
+    return new OrderCannotBeCancelledException(
+        MESSAGE_TEMPLATE.formatted(
+            order.getOrderId().getValue(),
+            order.getOrderCode().getValue(),
+            order.getOrderStatus().name()));
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderCode.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderCode.java
@@ -1,64 +1,55 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
+import java.util.regex.Pattern;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.regex.Pattern;
-
-/**
- * 注文コード
- */
+/** 注文コード */
 @Getter
 @ToString
 @EqualsAndHashCode
 public class OrderCode {
 
-    /**
-     * 注文コード形式不一致時の例外メッセージ
-     */
-    private static final String INVALID_FORMAT_MESSAGE = "注文コード（ORD000001）の形式と不一致です。";
+  /** 注文コード形式不一致時の例外メッセージ */
+  private static final String INVALID_FORMAT_MESSAGE = "注文コード（ORD000001）の形式と不一致です。";
 
-    /**
-     * 注文コードパターン
-     */
-    private static final Pattern ORDER_CODE_PATTERN = Pattern.compile("^ORD\\d{6}$");
+  /** 注文コードパターン */
+  private static final Pattern ORDER_CODE_PATTERN = Pattern.compile("^ORD\\d{6}$");
 
-    /**
-     * 注文コード文字列
-     */
-    private final String value;
+  /** 注文コード文字列 */
+  private final String value;
 
-    /**
-     * コンストラクタ
-     *
-     * @param value 注文コード文字列
-     */
-    private OrderCode(final String value) {
-        if (value == null || !ORDER_CODE_PATTERN.matcher(value).matches()) {
-            throw new IllegalArgumentException(INVALID_FORMAT_MESSAGE);
-        }
-        this.value = value;
+  /**
+   * コンストラクタ
+   *
+   * @param value 注文コード文字列
+   */
+  private OrderCode(final String value) {
+    if (value == null || !ORDER_CODE_PATTERN.matcher(value).matches()) {
+      throw new IllegalArgumentException(INVALID_FORMAT_MESSAGE);
     }
+    this.value = value;
+  }
 
-    /**
-     * 注文コード(String)から注文コードを生成する
-     *
-     * @param value 注文コード(String)
-     * @return 注文コード
-     * @throws IllegalArgumentException 注文コードの形式が不正な場合
-     */
-    public static OrderCode of(final String value) {
-        return new OrderCode(value);
-    }
+  /**
+   * 注文コード(String)から注文コードを生成する
+   *
+   * @param value 注文コード(String)
+   * @return 注文コード
+   * @throws IllegalArgumentException 注文コードの形式が不正な場合
+   */
+  public static OrderCode of(final String value) {
+    return new OrderCode(value);
+  }
 
-    /**
-     * 注文コード文字列が有効形式か判定する
-     *
-     * @param value 注文コード文字列
-     * @return 注文コード文字列が有効形式の場合 true
-     */
-    public static boolean isValid(final String value) {
-        return value != null && ORDER_CODE_PATTERN.matcher(value).matches();
-    }
+  /**
+   * 注文コード文字列が有効形式か判定する
+   *
+   * @param value 注文コード文字列
+   * @return 注文コード文字列が有効形式の場合 true
+   */
+  public static boolean isValid(final String value) {
+    return value != null && ORDER_CODE_PATTERN.matcher(value).matches();
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderCodeGenerator.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderCodeGenerator.java
@@ -1,14 +1,12 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
-/**
- * 注文コード採番
- */
+/** 注文コード採番 */
 public interface OrderCodeGenerator {
 
-    /**
-     * 注文コードを採番する
-     *
-     * @return 注文コード
-     */
-    OrderCode generate();
+  /**
+   * 注文コードを採番する
+   *
+   * @return 注文コード
+   */
+  OrderCode generate();
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderId.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderId.java
@@ -1,50 +1,45 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
+import java.util.Objects;
+import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.Objects;
-import java.util.UUID;
-
-/**
- * 注文ID
- */
+/** 注文ID */
 @Getter
 @ToString
 @EqualsAndHashCode
 public class OrderId {
 
-    /**
-     * 注文ID
-     */
-    private final UUID value;
+  /** 注文ID */
+  private final UUID value;
 
-    /**
-     * コンストラクタ
-     *
-     * @param value 注文ID
-     */
-    private OrderId(final UUID value) {
-        this.value = Objects.requireNonNull(value, "注文IDは必須です。");
-    }
+  /**
+   * コンストラクタ
+   *
+   * @param value 注文ID
+   */
+  private OrderId(final UUID value) {
+    this.value = Objects.requireNonNull(value, "注文IDは必須です。");
+  }
 
-    /**
-     * 注文IDを採番する
-     *
-     * @return 注文ID
-     */
-    public static OrderId generate() {
-        return new OrderId(UUID.randomUUID());
-    }
+  /**
+   * 注文IDを採番する
+   *
+   * @return 注文ID
+   */
+  public static OrderId generate() {
+    return new OrderId(UUID.randomUUID());
+  }
 
-    /**
-     * 注文ID(UUID)から注文IDを生成する
-     *
-     * @param value 注文ID(UUID)
-     * @return 注文ID
-     */
-    public static OrderId of(final UUID value) {
-        return new OrderId(value);
-    }
+  /**
+   * 注文ID(UUID)から注文IDを生成する
+   *
+   * @param value 注文ID(UUID)
+   * @return 注文ID
+   */
+  public static OrderId of(final UUID value) {
+    return new OrderId(value);
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderNotFoundException.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderNotFoundException.java
@@ -1,31 +1,27 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
-/**
- * 注文未存在例外
- */
+/** 注文未存在例外 */
 public class OrderNotFoundException extends RuntimeException {
 
-    /**
-     * 注文未存在時のログ用メッセージテンプレート
-     */
-    private static final String MESSAGE_TEMPLATE = "注文が見つかりません: orderCode=%s";
+  /** 注文未存在時のログ用メッセージテンプレート */
+  private static final String MESSAGE_TEMPLATE = "注文が見つかりません: orderCode=%s";
 
-    /**
-     * コンストラクタ
-     *
-     * @param message 例外メッセージ
-     */
-    private OrderNotFoundException(final String message) {
-        super(message);
-    }
+  /**
+   * コンストラクタ
+   *
+   * @param message 例外メッセージ
+   */
+  private OrderNotFoundException(final String message) {
+    super(message);
+  }
 
-    /**
-     * 注文コードで注文が見つからない場合の例外を生成する
-     *
-     * @param orderCode 見つからなかった注文コード
-     * @return 注文未存在例外
-     */
-    public static OrderNotFoundException byOrderCode(final String orderCode) {
-        return new OrderNotFoundException(MESSAGE_TEMPLATE.formatted(orderCode));
-    }
+  /**
+   * 注文コードで注文が見つからない場合の例外を生成する
+   *
+   * @param orderCode 見つからなかった注文コード
+   * @return 注文未存在例外
+   */
+  public static OrderNotFoundException byOrderCode(final String orderCode) {
+    return new OrderNotFoundException(MESSAGE_TEMPLATE.formatted(orderCode));
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepository.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepository.java
@@ -1,45 +1,42 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
+import java.util.Optional;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PageResult;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PagingCondition;
 
-import java.util.Optional;
-
-/**
- * 注文リポジトリ
- */
+/** 注文リポジトリ */
 public interface OrderRepository {
 
-    /**
-     * 注文一覧を取得する
-     *
-     * @param pagingCondition ページング条件
-     * @return 注文日時降順、同一日時は注文コード降順のページング済み注文一覧。存在しない場合または範囲外ページの場合は空のページ
-     */
-    PageResult<Order> findAll(PagingCondition pagingCondition);
+  /**
+   * 注文一覧を取得する
+   *
+   * @param pagingCondition ページング条件
+   * @return 注文日時降順、同一日時は注文コード降順のページング済み注文一覧。存在しない場合または範囲外ページの場合は空のページ
+   */
+  PageResult<Order> findAll(PagingCondition pagingCondition);
 
-    /**
-     * 注文コードで注文を取得する
-     *
-     * @param orderCode 注文コード
-     * @return 注文。存在しない場合は空の Optional
-     */
-    Optional<Order> findByOrderCode(OrderCode orderCode);
+  /**
+   * 注文コードで注文を取得する
+   *
+   * @param orderCode 注文コード
+   * @return 注文。存在しない場合は空の Optional
+   */
+  Optional<Order> findByOrderCode(OrderCode orderCode);
 
-    /**
-     * 注文を登録する
-     *
-     * @param order 注文
-     * @return 注文
-     */
-    Order create(Order order);
+  /**
+   * 注文を登録する
+   *
+   * @param order 注文
+   * @return 注文
+   */
+  Order create(Order order);
 
-    /**
-     * 注文を更新する
-     *
-     * @param order 注文
-     * @return 注文
-     * @throws OrderVersionConflictException 更新対象の注文バージョンが一致しない場合
-     */
-    Order update(Order order);
+  /**
+   * 注文を更新する
+   *
+   * @param order 注文
+   * @return 注文
+   * @throws OrderVersionConflictException 更新対象の注文バージョンが一致しない場合
+   */
+  Order update(Order order);
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderStatus.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderStatus.java
@@ -2,74 +2,65 @@ package jp.co.shimizutdev.phoneorderapi.domain.order;
 
 import lombok.Getter;
 
-/**
- * 注文ステータス
- */
+/** 注文ステータス */
 @Getter
 public enum OrderStatus {
+  RECEIVED("001", "受付"),
+  UNDER_REVIEW("002", "審査中"),
+  ARRANGING("003", "手配中"),
+  WAITING_SHIPMENT("004", "出荷待ち"),
+  COMPLETED("005", "完了"),
+  CANCELLED("006", "キャンセル");
 
-    RECEIVED("001", "受付"),
-    UNDER_REVIEW("002", "審査中"),
-    ARRANGING("003", "手配中"),
-    WAITING_SHIPMENT("004", "出荷待ち"),
-    COMPLETED("005", "完了"),
-    CANCELLED("006", "キャンセル");
+  /** 注文ステータスコード不正時の例外メッセージ */
+  private static final String INVALID_CODE_MESSAGE = "注文ステータスコードが不正です。";
 
-    /**
-     * 注文ステータスコード不正時の例外メッセージ
-     */
-    private static final String INVALID_CODE_MESSAGE = "注文ステータスコードが不正です。";
+  /** コード */
+  private final String code;
 
-    /**
-     * コード
-     */
-    private final String code;
+  /** 名称 */
+  private final String name;
 
-    /**
-     * 名称
-     */
-    private final String name;
+  /**
+   * コンストラクタ
+   *
+   * @param code コード
+   * @param name 名称
+   */
+  OrderStatus(final String code, final String name) {
+    this.code = code;
+    this.name = name;
+  }
 
-    /**
-     * コンストラクタ
-     *
-     * @param code コード
-     * @param name 名称
-     */
-    OrderStatus(final String code, final String name) {
-        this.code = code;
-        this.name = name;
-    }
+  /**
+   * コードから注文ステータスへ生成する
+   *
+   * @param code コード
+   * @return 注文ステータス
+   * @throws IllegalArgumentException 注文ステータスコードが不正な場合
+   */
+  public static OrderStatus fromCode(final String code) {
+    return switch (code) {
+      case "001" -> OrderStatus.RECEIVED;
+      case "002" -> OrderStatus.UNDER_REVIEW;
+      case "003" -> OrderStatus.ARRANGING;
+      case "004" -> OrderStatus.WAITING_SHIPMENT;
+      case "005" -> OrderStatus.COMPLETED;
+      case "006" -> OrderStatus.CANCELLED;
+      default -> throw new IllegalArgumentException(INVALID_CODE_MESSAGE);
+    };
+  }
 
-    /**
-     * コードから注文ステータスへ生成する
-     *
-     * @param code コード
-     * @return 注文ステータス
-     * @throws IllegalArgumentException 注文ステータスコードが不正な場合
-     */
-    public static OrderStatus fromCode(final String code) {
-        return switch (code) {
-            case "001" -> OrderStatus.RECEIVED;
-            case "002" -> OrderStatus.UNDER_REVIEW;
-            case "003" -> OrderStatus.ARRANGING;
-            case "004" -> OrderStatus.WAITING_SHIPMENT;
-            case "005" -> OrderStatus.COMPLETED;
-            case "006" -> OrderStatus.CANCELLED;
-            default -> throw new IllegalArgumentException(INVALID_CODE_MESSAGE);
-        };
-    }
-
-    /**
-     * 注文ステータスコードが有効か判定する
-     *
-     * @param code 注文ステータスコード
-     * @return 注文ステータスコードが有効な場合 true
-     */
-    public static boolean isValidCode(final String code) {
-        return switch (code) {
-            case "001", "002", "003", "004", "005", "006" -> true;
-            default -> false;
-        };
-    }
+  /**
+   * 注文ステータスコードが有効か判定する
+   *
+   * @param code 注文ステータスコード
+   * @return 注文ステータスコードが有効な場合 true
+   */
+  public static boolean isValidCode(final String code) {
+    return switch (code) {
+      case "001", "002", "003", "004", "005", "006" -> true;
+      default -> false;
+    };
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderVersionConflictException.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderVersionConflictException.java
@@ -1,65 +1,54 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
-/**
- * 注文楽観的ロック競合例外
- */
+/** 注文楽観的ロック競合例外 */
 public class OrderVersionConflictException extends RuntimeException {
 
-    /**
-     * キャンセル要求時のバージョン競合を表すログ用メッセージテンプレート
-     */
-    private static final String CANCEL_MESSAGE_TEMPLATE =
-        "注文のバージョンが競合しています: orderId=%s, orderCode=%s, currentVersion=%d, requestedVersion=%d";
+  /** キャンセル要求時のバージョン競合を表すログ用メッセージテンプレート */
+  private static final String CANCEL_MESSAGE_TEMPLATE =
+      "注文のバージョンが競合しています: orderId=%s, orderCode=%s, currentVersion=%d, requestedVersion=%d";
 
-    /**
-     * 更新時のバージョン競合を表すログ用メッセージテンプレート
-     */
-    private static final String UPDATE_MESSAGE_TEMPLATE =
-        "注文のバージョンが競合しています: orderId=%s, orderCode=%s, version=%d";
+  /** 更新時のバージョン競合を表すログ用メッセージテンプレート */
+  private static final String UPDATE_MESSAGE_TEMPLATE =
+      "注文のバージョンが競合しています: orderId=%s, orderCode=%s, version=%d";
 
-    /**
-     * コンストラクタ
-     *
-     * @param message 例外メッセージ
-     */
-    private OrderVersionConflictException(final String message) {
-        super(message);
-    }
+  /**
+   * コンストラクタ
+   *
+   * @param message 例外メッセージ
+   */
+  private OrderVersionConflictException(final String message) {
+    super(message);
+  }
 
-    /**
-     * 要求バージョンと現在バージョンが一致しない場合の例外を生成する
-     *
-     * @param order            バージョン競合が発生した注文
-     * @param requestedVersion 要求されたバージョン
-     * @return 注文バージョン競合例外
-     */
-    public static OrderVersionConflictException byOrder(
-        final Order order,
-        final Version requestedVersion) {
+  /**
+   * 要求バージョンと現在バージョンが一致しない場合の例外を生成する
+   *
+   * @param order バージョン競合が発生した注文
+   * @param requestedVersion 要求されたバージョン
+   * @return 注文バージョン競合例外
+   */
+  public static OrderVersionConflictException byOrder(
+      final Order order, final Version requestedVersion) {
 
-        return new OrderVersionConflictException(
-            CANCEL_MESSAGE_TEMPLATE.formatted(
-                order.getOrderId().getValue(),
-                order.getOrderCode().getValue(),
-                order.getVersion().getValue(),
-                requestedVersion.getValue()
-            )
-        );
-    }
+    return new OrderVersionConflictException(
+        CANCEL_MESSAGE_TEMPLATE.formatted(
+            order.getOrderId().getValue(),
+            order.getOrderCode().getValue(),
+            order.getVersion().getValue(),
+            requestedVersion.getValue()));
+  }
 
-    /**
-     * 永続化層で注文更新対象が見つからない場合の例外を生成する
-     *
-     * @param order 更新対象の注文
-     * @return 注文バージョン競合例外
-     */
-    public static OrderVersionConflictException byOrderForUpdate(final Order order) {
-        return new OrderVersionConflictException(
-            UPDATE_MESSAGE_TEMPLATE.formatted(
-                order.getOrderId().getValue(),
-                order.getOrderCode().getValue(),
-                order.getVersion().getValue()
-            )
-        );
-    }
+  /**
+   * 永続化層で注文更新対象が見つからない場合の例外を生成する
+   *
+   * @param order 更新対象の注文
+   * @return 注文バージョン競合例外
+   */
+  public static OrderVersionConflictException byOrderForUpdate(final Order order) {
+    return new OrderVersionConflictException(
+        UPDATE_MESSAGE_TEMPLATE.formatted(
+            order.getOrderId().getValue(),
+            order.getOrderCode().getValue(),
+            order.getVersion().getValue()));
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderedAt.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderedAt.java
@@ -1,49 +1,42 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
+import java.time.OffsetDateTime;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.time.OffsetDateTime;
-
-/**
- * 注文日時
- */
+/** 注文日時 */
 @Getter
 @ToString
 @EqualsAndHashCode
 public class OrderedAt {
 
-    /**
-     * 注文日時未指定時の例外メッセージ
-     */
-    private static final String REQUIRED_MESSAGE = "注文日時は必須です。";
+  /** 注文日時未指定時の例外メッセージ */
+  private static final String REQUIRED_MESSAGE = "注文日時は必須です。";
 
-    /**
-     * 注文日時
-     */
-    private final OffsetDateTime value;
+  /** 注文日時 */
+  private final OffsetDateTime value;
 
-    /**
-     * コンストラクタ
-     *
-     * @param value 注文日時
-     */
-    private OrderedAt(final OffsetDateTime value) {
-        if (value == null) {
-            throw new IllegalArgumentException(REQUIRED_MESSAGE);
-        }
-        this.value = value;
+  /**
+   * コンストラクタ
+   *
+   * @param value 注文日時
+   */
+  private OrderedAt(final OffsetDateTime value) {
+    if (value == null) {
+      throw new IllegalArgumentException(REQUIRED_MESSAGE);
     }
+    this.value = value;
+  }
 
-    /**
-     * 注文日時(OffsetDateTime)から注文日時を生成する
-     *
-     * @param value 注文日時(OffsetDateTime)
-     * @return 注文日時
-     * @throws IllegalArgumentException 注文日時が指定されていない場合
-     */
-    public static OrderedAt of(final OffsetDateTime value) {
-        return new OrderedAt(value);
-    }
+  /**
+   * 注文日時(OffsetDateTime)から注文日時を生成する
+   *
+   * @param value 注文日時(OffsetDateTime)
+   * @return 注文日時
+   * @throws IllegalArgumentException 注文日時が指定されていない場合
+   */
+  public static OrderedAt of(final OffsetDateTime value) {
+    return new OrderedAt(value);
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/Version.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/domain/order/Version.java
@@ -4,45 +4,39 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-/**
- * バージョン
- */
+/** バージョン */
 @Getter
 @ToString
 @EqualsAndHashCode
 public class Version {
 
-    /**
-     * バージョン値不正時の例外メッセージ
-     */
-    private static final String INVALID_VALUE_MESSAGE = "バージョンは0以上である必要があります。";
+  /** バージョン値不正時の例外メッセージ */
+  private static final String INVALID_VALUE_MESSAGE = "バージョンは0以上である必要があります。";
 
-    /**
-     * バージョン値
-     */
-    private final long value;
+  /** バージョン値 */
+  private final long value;
 
-    /**
-     * コンストラクタ
-     *
-     * @param value バージョン値
-     */
-    private Version(final long value) {
-        if (value < 0) {
-            throw new IllegalArgumentException(INVALID_VALUE_MESSAGE);
-        }
-
-        this.value = value;
+  /**
+   * コンストラクタ
+   *
+   * @param value バージョン値
+   */
+  private Version(final long value) {
+    if (value < 0) {
+      throw new IllegalArgumentException(INVALID_VALUE_MESSAGE);
     }
 
-    /**
-     * バージョン(long)からバージョンを生成する
-     *
-     * @param value バージョン(long)
-     * @return バージョン
-     * @throws IllegalArgumentException バージョンが0未満の場合
-     */
-    public static Version of(final long value) {
-        return new Version(value);
-    }
+    this.value = value;
+  }
+
+  /**
+   * バージョン(long)からバージョンを生成する
+   *
+   * @param value バージョン(long)
+   * @return バージョン
+   * @throws IllegalArgumentException バージョンが0未満の場合
+   */
+  public static Version of(final long value) {
+    return new Version(value);
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/codegen/SequenceOrderCodeGenerator.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/codegen/SequenceOrderCodeGenerator.java
@@ -6,25 +6,21 @@ import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.OrderJpa
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-/**
- * 連番形式の注文コード採番
- */
+/** 連番形式の注文コード採番 */
 @Component
 @RequiredArgsConstructor
 public class SequenceOrderCodeGenerator implements OrderCodeGenerator {
 
-    /**
-     * 注文リポジトリ
-     */
-    private final OrderJpaRepository orderJpaRepository;
+  /** 注文リポジトリ */
+  private final OrderJpaRepository orderJpaRepository;
 
-    /**
-     * 注文コードを採番する
-     *
-     * @return 注文コード
-     */
-    @Override
-    public OrderCode generate() {
-        return OrderCode.of(orderJpaRepository.nextOrderCode());
-    }
+  /**
+   * 注文コードを採番する
+   *
+   * @return 注文コード
+   */
+  @Override
+  public OrderCode generate() {
+    return OrderCode.of(orderJpaRepository.nextOrderCode());
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/config/InvalidAuditorException.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/config/InvalidAuditorException.java
@@ -2,17 +2,17 @@ package jp.co.shimizutdev.phoneorderapi.infrastructure.config;
 
 /**
  * 監査ユーザー不正例外。
- * <p>
- * リクエストヘッダーから解決した監査ユーザーが DB の監査項目へ保存できない場合に送出する。
+ *
+ * <p>リクエストヘッダーから解決した監査ユーザーが DB の監査項目へ保存できない場合に送出する。
  */
 public class InvalidAuditorException extends RuntimeException {
 
-    /**
-     * コンストラクタ
-     *
-     * @param message 例外メッセージ
-     */
-    public InvalidAuditorException(final String message) {
-        super(message);
-    }
+  /**
+   * コンストラクタ
+   *
+   * @param message 例外メッセージ
+   */
+  public InvalidAuditorException(final String message) {
+    super(message);
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/config/JpaAuditConfig.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/config/JpaAuditConfig.java
@@ -1,6 +1,8 @@
 package jp.co.shimizutdev.phoneorderapi.infrastructure.config;
 
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
@@ -8,95 +10,80 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.util.List;
-import java.util.Optional;
-
-/**
- * JPA監査設定
- */
+/** JPA監査設定 */
 @Configuration
 public class JpaAuditConfig {
 
-    /**
-     * 監査ユーザー最大文字数
-     */
-    private static final int AUDITOR_MAX_LENGTH = 50;
+  /** 監査ユーザー最大文字数 */
+  private static final int AUDITOR_MAX_LENGTH = 50;
 
-    /**
-     * 監査ユーザー最大文字数超過時の例外メッセージ
-     */
-    private static final String AUDITOR_TOO_LONG_MESSAGE = "監査ユーザーは50文字以内で指定してください。";
+  /** 監査ユーザー最大文字数超過時の例外メッセージ */
+  private static final String AUDITOR_TOO_LONG_MESSAGE = "監査ユーザーは50文字以内で指定してください。";
 
-    /**
-     * 監査ユーザーを解決するために参照するヘッダー名一覧
-     */
-    private static final List<String> AUDITOR_HEADER_NAMES = List.of(
-        "X-User-Id",
-        "X-User-Name",
-        "X-Actor"
-    );
+  /** 監査ユーザーを解決するために参照するヘッダー名一覧 */
+  private static final List<String> AUDITOR_HEADER_NAMES =
+      List.of("X-User-Id", "X-User-Name", "X-Actor");
 
-    /**
-     * 監査担当者を取得する。
-     * <p>
-     * 現在の HTTP リクエストから監査ユーザーを解決し、リクエストが存在しない場合または
-     * 監査ユーザー用ヘッダーが未指定の場合は {@code system} を返す。
-     *
-     * @return 監査担当者
-     * @throws InvalidAuditorException 監査ユーザーが最大文字数を超過している場合
-     */
-    @Bean
-    public AuditorAware<String> auditorAware() {
-        return () -> currentRequest()
+  /**
+   * 監査担当者を取得する。
+   *
+   * <p>現在の HTTP リクエストから監査ユーザーを解決し、リクエストが存在しない場合または 監査ユーザー用ヘッダーが未指定の場合は {@code system} を返す。
+   *
+   * @return 監査担当者
+   * @throws InvalidAuditorException 監査ユーザーが最大文字数を超過している場合
+   */
+  @Bean
+  public AuditorAware<String> auditorAware() {
+    return () ->
+        currentRequest()
             .map(this::resolveAuditor)
             .filter(StringUtils::hasText)
             .or(() -> Optional.of("system"));
+  }
+
+  /**
+   * 現在の HTTP リクエストを取得する
+   *
+   * @return HTTP リクエスト。存在しない場合は空の Optional
+   */
+  private Optional<HttpServletRequest> currentRequest() {
+    return Optional.ofNullable(RequestContextHolder.getRequestAttributes())
+        .filter(ServletRequestAttributes.class::isInstance)
+        .map(ServletRequestAttributes.class::cast)
+        .map(ServletRequestAttributes::getRequest);
+  }
+
+  /**
+   * リクエストヘッダーから監査ユーザーを解決する。
+   *
+   * <p>{@code X-User-Id}、{@code X-User-Name}、{@code X-Actor} の順に参照し、 最初に見つかった空でないヘッダー値を使用する。
+   *
+   * @param request HTTP リクエスト
+   * @return 監査ユーザー。対象ヘッダーが存在しない場合は null
+   * @throws InvalidAuditorException 監査ユーザーが最大文字数を超過している場合
+   */
+  private String resolveAuditor(final HttpServletRequest request) {
+    return AUDITOR_HEADER_NAMES.stream()
+        .map(request::getHeader)
+        .filter(StringUtils::hasText)
+        .map(String::trim)
+        .map(this::validateAuditorLength)
+        .findFirst()
+        .orElse(null);
+  }
+
+  /**
+   * 監査ユーザーの文字数を検証する
+   *
+   * @param auditor 監査ユーザー
+   * @return 検証済み監査ユーザー
+   * @throws InvalidAuditorException 監査ユーザーが最大文字数を超過している場合
+   */
+  private String validateAuditorLength(final String auditor) {
+    if (auditor.length() > AUDITOR_MAX_LENGTH) {
+      throw new InvalidAuditorException(AUDITOR_TOO_LONG_MESSAGE);
     }
 
-    /**
-     * 現在の HTTP リクエストを取得する
-     *
-     * @return HTTP リクエスト。存在しない場合は空の Optional
-     */
-    private Optional<HttpServletRequest> currentRequest() {
-        return Optional.ofNullable(RequestContextHolder.getRequestAttributes())
-            .filter(ServletRequestAttributes.class::isInstance)
-            .map(ServletRequestAttributes.class::cast)
-            .map(ServletRequestAttributes::getRequest);
-    }
-
-    /**
-     * リクエストヘッダーから監査ユーザーを解決する。
-     * <p>
-     * {@code X-User-Id}、{@code X-User-Name}、{@code X-Actor} の順に参照し、
-     * 最初に見つかった空でないヘッダー値を使用する。
-     *
-     * @param request HTTP リクエスト
-     * @return 監査ユーザー。対象ヘッダーが存在しない場合は null
-     * @throws InvalidAuditorException 監査ユーザーが最大文字数を超過している場合
-     */
-    private String resolveAuditor(final HttpServletRequest request) {
-        return AUDITOR_HEADER_NAMES.stream()
-            .map(request::getHeader)
-            .filter(StringUtils::hasText)
-            .map(String::trim)
-            .map(this::validateAuditorLength)
-            .findFirst()
-            .orElse(null);
-    }
-
-    /**
-     * 監査ユーザーの文字数を検証する
-     *
-     * @param auditor 監査ユーザー
-     * @return 検証済み監査ユーザー
-     * @throws InvalidAuditorException 監査ユーザーが最大文字数を超過している場合
-     */
-    private String validateAuditorLength(final String auditor) {
-        if (auditor.length() > AUDITOR_MAX_LENGTH) {
-            throw new InvalidAuditorException(AUDITOR_TOO_LONG_MESSAGE);
-        }
-
-        return auditor;
-    }
+    return auditor;
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/LogMasker.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/LogMasker.java
@@ -5,207 +5,187 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
-
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
-/**
- * ログマスキング
- */
+/** ログマスキング */
 @Component
 @RequiredArgsConstructor
 public class LogMasker {
 
-    /**
-     * マスク文字列
-     */
-    private static final String MASKED_VALUE = "****";
+  /** マスク文字列 */
+  private static final String MASKED_VALUE = "****";
 
-    /**
-     * マスク対象ヘッダー名
-     */
-    private static final Set<String> MASK_TARGET_HEADER_NAMES = Set.of(
-        "authorization",
-        "cookie",
-        "set-cookie",
-        "x-api-key",
-        "proxy-authorization"
-    );
+  /** マスク対象ヘッダー名 */
+  private static final Set<String> MASK_TARGET_HEADER_NAMES =
+      Set.of("authorization", "cookie", "set-cookie", "x-api-key", "proxy-authorization");
 
-    /**
-     * マスク対象項目名
-     */
-    private static final Set<String> MASK_TARGET_FIELD_NAMES = Set.of(
-        "password",
-        "passwd",
-        "token",
-        "access_token",
-        "refresh_token",
-        "authorization",
-        "secret",
-        "api_key",
-        "apikey",
-        "card_number",
-        "phone_number",
-        "email",
-        "mail"
-    );
+  /** マスク対象項目名 */
+  private static final Set<String> MASK_TARGET_FIELD_NAMES =
+      Set.of(
+          "password",
+          "passwd",
+          "token",
+          "access_token",
+          "refresh_token",
+          "authorization",
+          "secret",
+          "api_key",
+          "apikey",
+          "card_number",
+          "phone_number",
+          "email",
+          "mail");
 
-    /**
-     * オブジェクトマッパー
-     */
-    private final ObjectMapper objectMapper;
+  /** オブジェクトマッパー */
+  private final ObjectMapper objectMapper;
 
-    /**
-     * ヘッダー値をマスキングする
-     *
-     * @param headerName  ヘッダー名
-     * @param headerValue ヘッダー値
-     * @return マスキング後ヘッダー値
-     */
-    public String maskHeader(final String headerName, final String headerValue) {
-        if (headerValue == null) {
-            return "";
-        }
-
-        if (headerName == null) {
-            return headerValue;
-        }
-
-        if (MASK_TARGET_HEADER_NAMES.contains(normalizeName(headerName))) {
-            return MASKED_VALUE;
-        }
-
-        return headerValue;
+  /**
+   * ヘッダー値をマスキングする
+   *
+   * @param headerName ヘッダー名
+   * @param headerValue ヘッダー値
+   * @return マスキング後ヘッダー値
+   */
+  public String maskHeader(final String headerName, final String headerValue) {
+    if (headerValue == null) {
+      return "";
     }
 
-    /**
-     * テキストをマスキングする
-     *
-     * @param text テキスト
-     * @return マスキング後テキスト
-     */
-    public String maskText(final String text) {
-        if (text == null || text.isBlank()) {
-            return "";
-        }
-
-        try {
-            JsonNode root = objectMapper.readTree(text);
-            maskJsonNode(root);
-            return objectMapper.writeValueAsString(root);
-        } catch (Exception ex) {
-            return normalizeWhitespace(text);
-        }
+    if (headerName == null) {
+      return headerValue;
     }
 
-    /**
-     * オブジェクトをマスキングする
-     *
-     * @param value マスキング対象オブジェクト
-     * @return マスキング後文字列
-     */
-    public String maskObject(final Object value) {
-        if (value == null) {
-            return "";
-        }
-
-        try {
-            JsonNode root = objectMapper.valueToTree(value);
-            maskJsonNode(root);
-            return objectMapper.writeValueAsString(root);
-        } catch (JsonProcessingException | IllegalArgumentException ex) {
-            return normalizeWhitespace(String.valueOf(value));
-        }
+    if (MASK_TARGET_HEADER_NAMES.contains(normalizeName(headerName))) {
+      return MASKED_VALUE;
     }
 
-    /**
-     * JSONノードを再帰的にマスキングする
-     *
-     * @param node JSONノード
-     */
-    private void maskJsonNode(final JsonNode node) {
-        switch (node) {
-            case ObjectNode objectNode -> maskObjectNode(objectNode);
-            case ArrayNode arrayNode -> maskArrayNode(arrayNode);
-            default -> {
-                // ObjectNode / ArrayNode 以外の値ノードは再帰的に走査する項目がないため、マスキングしない
-            }
-        }
+    return headerValue;
+  }
+
+  /**
+   * テキストをマスキングする
+   *
+   * @param text テキスト
+   * @return マスキング後テキスト
+   */
+  public String maskText(final String text) {
+    if (text == null || text.isBlank()) {
+      return "";
     }
 
-    /**
-     * JSONオブジェクトをマスキングする
-     *
-     * @param objectNode JSONオブジェクト
-     */
-    private void maskObjectNode(final ObjectNode objectNode) {
-        objectNode.properties().forEach(entry -> maskObjectNodeEntry(objectNode, entry));
+    try {
+      JsonNode root = objectMapper.readTree(text);
+      maskJsonNode(root);
+      return objectMapper.writeValueAsString(root);
+    } catch (Exception ex) {
+      return normalizeWhitespace(text);
+    }
+  }
+
+  /**
+   * オブジェクトをマスキングする
+   *
+   * @param value マスキング対象オブジェクト
+   * @return マスキング後文字列
+   */
+  public String maskObject(final Object value) {
+    if (value == null) {
+      return "";
     }
 
-    /**
-     * JSONオブジェクトの項目をマスキングする
-     *
-     * @param objectNode JSONオブジェクト
-     * @param entry      項目
-     */
-    private void maskObjectNodeEntry(
-        final ObjectNode objectNode,
-        final Map.Entry<String, JsonNode> entry) {
+    try {
+      JsonNode root = objectMapper.valueToTree(value);
+      maskJsonNode(root);
+      return objectMapper.writeValueAsString(root);
+    } catch (JsonProcessingException | IllegalArgumentException ex) {
+      return normalizeWhitespace(String.valueOf(value));
+    }
+  }
 
-        String fieldName = entry.getKey();
-        JsonNode childNode = entry.getValue();
+  /**
+   * JSONノードを再帰的にマスキングする
+   *
+   * @param node JSONノード
+   */
+  private void maskJsonNode(final JsonNode node) {
+    switch (node) {
+      case ObjectNode objectNode -> maskObjectNode(objectNode);
+      case ArrayNode arrayNode -> maskArrayNode(arrayNode);
+      default -> {
+        // ObjectNode / ArrayNode 以外の値ノードは再帰的に走査する項目がないため、マスキングしない
+      }
+    }
+  }
 
-        if (isMaskTargetField(fieldName)) {
-            objectNode.put(fieldName, MASKED_VALUE);
-            return;
-        }
+  /**
+   * JSONオブジェクトをマスキングする
+   *
+   * @param objectNode JSONオブジェクト
+   */
+  private void maskObjectNode(final ObjectNode objectNode) {
+    objectNode.properties().forEach(entry -> maskObjectNodeEntry(objectNode, entry));
+  }
 
-        maskJsonNode(childNode);
+  /**
+   * JSONオブジェクトの項目をマスキングする
+   *
+   * @param objectNode JSONオブジェクト
+   * @param entry 項目
+   */
+  private void maskObjectNodeEntry(
+      final ObjectNode objectNode, final Map.Entry<String, JsonNode> entry) {
+
+    String fieldName = entry.getKey();
+    JsonNode childNode = entry.getValue();
+
+    if (isMaskTargetField(fieldName)) {
+      objectNode.put(fieldName, MASKED_VALUE);
+      return;
     }
 
-    /**
-     * JSON配列をマスキングする
-     *
-     * @param arrayNode JSON配列
-     */
-    private void maskArrayNode(final ArrayNode arrayNode) {
-        arrayNode.forEach(this::maskJsonNode);
-    }
+    maskJsonNode(childNode);
+  }
 
-    /**
-     * マスク対象項目か判定する
-     *
-     * @param fieldName 項目名
-     * @return マスク対象項目の場合 true
-     */
-    private boolean isMaskTargetField(final String fieldName) {
-        return MASK_TARGET_FIELD_NAMES.contains(normalizeName(fieldName));
-    }
+  /**
+   * JSON配列をマスキングする
+   *
+   * @param arrayNode JSON配列
+   */
+  private void maskArrayNode(final ArrayNode arrayNode) {
+    arrayNode.forEach(this::maskJsonNode);
+  }
 
-    /**
-     * 項目名を比較用へ正規化する
-     *
-     * @param name 名称
-     * @return 正規化後名称
-     */
-    private String normalizeName(final String name) {
-        return name.replace("-", "_")
-            .toLowerCase(Locale.ROOT);
-    }
+  /**
+   * マスク対象項目か判定する
+   *
+   * @param fieldName 項目名
+   * @return マスク対象項目の場合 true
+   */
+  private boolean isMaskTargetField(final String fieldName) {
+    return MASK_TARGET_FIELD_NAMES.contains(normalizeName(fieldName));
+  }
 
-    /**
-     * 文字列を1行へ正規化する
-     *
-     * @param text テキスト
-     * @return 正規化後テキスト
-     */
-    private String normalizeWhitespace(final String text) {
-        return text.replaceAll("\\R", " ")
-            .replaceAll("\\s{2,}", " ")
-            .trim();
-    }
+  /**
+   * 項目名を比較用へ正規化する
+   *
+   * @param name 名称
+   * @return 正規化後名称
+   */
+  private String normalizeName(final String name) {
+    return name.replace("-", "_").toLowerCase(Locale.ROOT);
+  }
+
+  /**
+   * 文字列を1行へ正規化する
+   *
+   * @param text テキスト
+   * @return 正規化後テキスト
+   */
+  private String normalizeWhitespace(final String text) {
+    return text.replaceAll("\\R", " ").replaceAll("\\s{2,}", " ").trim();
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspect.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspect.java
@@ -1,5 +1,11 @@
 package jp.co.shimizutdev.phoneorderapi.infrastructure.log;
 
+import java.lang.reflect.Array;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.ProceedingJoinPoint;
@@ -9,185 +15,171 @@ import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StopWatch;
 
-import java.lang.reflect.Array;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.util.Collection;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-/**
- * メソッド開始/終了ログ出力アスペクト
- */
+/** メソッド開始/終了ログ出力アスペクト */
 @Aspect
 @Component
 @Slf4j
 @RequiredArgsConstructor
 public class MethodLogAspect {
 
-    /**
-     * ログ最大文字数
-     */
-    private static final int MAX_LOG_LENGTH = 5000;
+  /** ログ最大文字数 */
+  private static final int MAX_LOG_LENGTH = 5000;
 
-    /**
-     * ログマスキング
-     */
-    private final LogMasker logMasker;
+  /** ログマスキング */
+  private final LogMasker logMasker;
 
-    /**
-     * メソッド開始 / 終了ログを出力する
-     *
-     * @param joinPoint JoinPoint
-     * @return 対象メソッドの戻り値
-     * @throws Throwable 対象メソッドの実行中に発生した例外
-     */
-    @Around(
-        "execution(* jp.co.shimizutdev.phoneorderapi.presentation..*Controller.*(..)) || "
-            + "execution(* jp.co.shimizutdev.phoneorderapi.application..*Service.*(..)) || "
-            + "execution(* jp.co.shimizutdev.phoneorderapi.infrastructure.repository..*RepositoryImpl.*(..))"
-    )
-    @SuppressWarnings("unused")
-    public Object logMethod(final ProceedingJoinPoint joinPoint) throws Throwable {
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        String className = signature.getDeclaringType().getSimpleName();
-        String methodName = signature.getMethod().getName();
-        String methodDisplayName = className + "#" + methodName;
+  /**
+   * メソッド開始 / 終了ログを出力する
+   *
+   * @param joinPoint JoinPoint
+   * @return 対象メソッドの戻り値
+   * @throws Throwable 対象メソッドの実行中に発生した例外
+   */
+  @Around(
+      "execution(* jp.co.shimizutdev.phoneorderapi.presentation..*Controller.*(..)) || execution(*"
+          + " jp.co.shimizutdev.phoneorderapi.application..*Service.*(..)) || execution(*"
+          + " jp.co.shimizutdev.phoneorderapi.infrastructure.repository..*RepositoryImpl.*(..))")
+  @SuppressWarnings("unused")
+  public Object logMethod(final ProceedingJoinPoint joinPoint) throws Throwable {
+    MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+    String className = signature.getDeclaringType().getSimpleName();
+    String methodName = signature.getMethod().getName();
+    String methodDisplayName = className + "#" + methodName;
 
-        StopWatch stopWatch = new StopWatch();
-        stopWatch.start();
+    StopWatch stopWatch = new StopWatch();
+    stopWatch.start();
 
-        log.info("[method start] methodName: {}", methodDisplayName);
+    log.info("[method start] methodName: {}", methodDisplayName);
 
-        if (log.isDebugEnabled()) {
-            log.debug(
-                "[method start] arguments: [{}] {}",
-                getRuntimeTypeName(joinPoint.getArgs()),
-                abbreviate(logMasker.maskObject(joinPoint.getArgs()))
-            );
-        }
-
-        try {
-            Object returnValue = joinPoint.proceed();
-
-            stopWatch.stop();
-
-            log.info("[method end] methodName: {}", methodDisplayName);
-            log.info("[method end] duration(ms): {}", stopWatch.getTotalTimeMillis());
-
-            if (log.isDebugEnabled()) {
-                log.debug(
-                    "[method end] return value: [{}] {}",
-                    getDeclaredReturnTypeName(signature, returnValue),
-                    abbreviate(logMasker.maskObject(returnValue))
-                );
-            }
-
-            return returnValue;
-        } catch (Throwable ex) {
-            if (stopWatch.isRunning()) {
-                stopWatch.stop();
-            }
-
-            log.warn("[method exception] {}", methodDisplayName);
-            log.warn("[method exception] class: {}", ex.getClass().getName());
-            log.warn("[method exception] message: {}", nullToEmpty(ex.getMessage()));
-            log.warn("[method exception] duration(ms): {}", stopWatch.getTotalTimeMillis());
-
-            throw ex;
-        }
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "[method start] arguments: [{}] {}",
+          getRuntimeTypeName(joinPoint.getArgs()),
+          abbreviate(logMasker.maskObject(joinPoint.getArgs())));
     }
 
-    /**
-     * 宣言上の戻り値型を取得する
-     *
-     * @param signature   メソッドシグネチャ
-     * @param returnValue 戻り値
-     * @return 戻り値型
-     */
-    private String getDeclaredReturnTypeName(final MethodSignature signature, final Object returnValue) {
-        String typeName = formatType(signature.getMethod().getGenericReturnType());
+    try {
+      Object returnValue = joinPoint.proceed();
 
-        if (returnValue instanceof Collection<?> collection) {
-            return typeName + "(size=" + collection.size() + ")";
-        }
+      stopWatch.stop();
 
-        if (returnValue != null && returnValue.getClass().isArray()) {
-            return typeName + "(length=" + Array.getLength(returnValue) + ")";
-        }
+      log.info("[method end] methodName: {}", methodDisplayName);
+      log.info("[method end] duration(ms): {}", stopWatch.getTotalTimeMillis());
 
-        return typeName;
+      if (log.isDebugEnabled()) {
+        log.debug(
+            "[method end] return value: [{}] {}",
+            getDeclaredReturnTypeName(signature, returnValue),
+            abbreviate(logMasker.maskObject(returnValue)));
+      }
+
+      return returnValue;
+    } catch (Throwable ex) {
+      if (stopWatch.isRunning()) {
+        stopWatch.stop();
+      }
+
+      log.warn("[method exception] {}", methodDisplayName);
+      log.warn("[method exception] class: {}", ex.getClass().getName());
+      log.warn("[method exception] message: {}", nullToEmpty(ex.getMessage()));
+      log.warn("[method exception] duration(ms): {}", stopWatch.getTotalTimeMillis());
+
+      throw ex;
+    }
+  }
+
+  /**
+   * 宣言上の戻り値型を取得する
+   *
+   * @param signature メソッドシグネチャ
+   * @param returnValue 戻り値
+   * @return 戻り値型
+   */
+  private String getDeclaredReturnTypeName(
+      final MethodSignature signature, final Object returnValue) {
+    String typeName = formatType(signature.getMethod().getGenericReturnType());
+
+    if (returnValue instanceof Collection<?> collection) {
+      return typeName + "(size=" + collection.size() + ")";
     }
 
-    /**
-     * 実行時の型名を取得する
-     *
-     * @param value 型名取得対象
-     * @return 実行時の型名
-     */
-    private String getRuntimeTypeName(final Object value) {
-        if (value == null) {
-            return "null";
-        }
-
-        return value.getClass().getSimpleName();
+    if (returnValue != null && returnValue.getClass().isArray()) {
+      return typeName + "(length=" + Array.getLength(returnValue) + ")";
     }
 
-    /**
-     * Typeを文字列へ整形する
-     *
-     * @param type 型
-     * @return 型名
-     */
-    private String formatType(final Type type) {
-        if (type instanceof ParameterizedType parameterizedType) {
-            String rawTypeName = simpleTypeName(parameterizedType.getRawType());
-            String actualTypeNames = Stream.of(parameterizedType.getActualTypeArguments())
-                .map(this::formatType)
-                .collect(Collectors.joining(", "));
-            return rawTypeName + "<" + actualTypeNames + ">";
-        }
+    return typeName;
+  }
 
-        return simpleTypeName(type);
+  /**
+   * 実行時の型名を取得する
+   *
+   * @param value 型名取得対象
+   * @return 実行時の型名
+   */
+  private String getRuntimeTypeName(final Object value) {
+    if (value == null) {
+      return "null";
     }
 
-    /**
-     * 型名をシンプル名へ変換する
-     *
-     * @param type 型
-     * @return シンプル名
-     */
-    private String simpleTypeName(final Type type) {
-        String typeName = type.getTypeName();
-        int lastDotIndex = typeName.lastIndexOf('.');
-        return lastDotIndex >= 0 ? typeName.substring(lastDotIndex + 1) : typeName;
+    return value.getClass().getSimpleName();
+  }
+
+  /**
+   * Typeを文字列へ整形する
+   *
+   * @param type 型
+   * @return 型名
+   */
+  private String formatType(final Type type) {
+    if (type instanceof ParameterizedType parameterizedType) {
+      String rawTypeName = simpleTypeName(parameterizedType.getRawType());
+      String actualTypeNames =
+          Stream.of(parameterizedType.getActualTypeArguments())
+              .map(this::formatType)
+              .collect(Collectors.joining(", "));
+      return rawTypeName + "<" + actualTypeNames + ">";
     }
 
-    /**
-     * ログ文字列を最大文字数に省略する
-     *
-     * @param value 省略対象文字列
-     * @return 省略後文字列
-     */
-    private String abbreviate(final String value) {
-        if (value == null) {
-            return "";
-        }
+    return simpleTypeName(type);
+  }
 
-        if (value.length() <= MAX_LOG_LENGTH) {
-            return value;
-        }
+  /**
+   * 型名をシンプル名へ変換する
+   *
+   * @param type 型
+   * @return シンプル名
+   */
+  private String simpleTypeName(final Type type) {
+    String typeName = type.getTypeName();
+    int lastDotIndex = typeName.lastIndexOf('.');
+    return lastDotIndex >= 0 ? typeName.substring(lastDotIndex + 1) : typeName;
+  }
 
-        return value.substring(0, MAX_LOG_LENGTH) + "...(truncated)";
+  /**
+   * ログ文字列を最大文字数に省略する
+   *
+   * @param value 省略対象文字列
+   * @return 省略後文字列
+   */
+  private String abbreviate(final String value) {
+    if (value == null) {
+      return "";
     }
 
-    /**
-     * null を空文字へ変換する
-     *
-     * @param value 変換対象文字列
-     * @return null の場合は空文字、それ以外の場合は変換対象文字列
-     */
-    private String nullToEmpty(final String value) {
-        return value == null ? "" : value;
+    if (value.length() <= MAX_LOG_LENGTH) {
+      return value;
     }
+
+    return value.substring(0, MAX_LOG_LENGTH) + "...(truncated)";
+  }
+
+  /**
+   * null を空文字へ変換する
+   *
+   * @param value 変換対象文字列
+   * @return null の場合は空文字、それ以外の場合は変換対象文字列
+   */
+  private String nullToEmpty(final String value) {
+    return value == null ? "" : value;
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/BaseAuditJpaEntity.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/BaseAuditJpaEntity.java
@@ -3,6 +3,7 @@ package jp.co.shimizutdev.phoneorderapi.infrastructure.persistence;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.OffsetDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,11 +14,7 @@ import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.LastModifiedBy;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.OffsetDateTime;
-
-/**
- * 基底監査JPAエンティティ
- */
+/** 基底監査JPAエンティティ */
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
@@ -25,43 +22,31 @@ import java.time.OffsetDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class BaseAuditJpaEntity {
 
-    /**
-     * 作成日時
-     */
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    private OffsetDateTime createdAt;
+  /** 作成日時 */
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private OffsetDateTime createdAt;
 
-    /**
-     * 作成者
-     */
-    @CreatedBy
-    @Column(name = "created_by", nullable = false, length = 50, updatable = false)
-    private String createdBy;
+  /** 作成者 */
+  @CreatedBy
+  @Column(name = "created_by", nullable = false, length = 50, updatable = false)
+  private String createdBy;
 
-    /**
-     * 更新日時
-     */
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    private OffsetDateTime updatedAt;
+  /** 更新日時 */
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
 
-    /**
-     * 更新者
-     */
-    @LastModifiedBy
-    @Column(name = "updated_by", nullable = false, length = 50)
-    private String updatedBy;
+  /** 更新者 */
+  @LastModifiedBy
+  @Column(name = "updated_by", nullable = false, length = 50)
+  private String updatedBy;
 
-    /**
-     * 削除日時
-     */
-    @Column(name = "deleted_at")
-    private OffsetDateTime deletedAt;
+  /** 削除日時 */
+  @Column(name = "deleted_at")
+  private OffsetDateTime deletedAt;
 
-    /**
-     * 削除者
-     */
-    @Column(name = "deleted_by", length = 50)
-    private String deletedBy;
+  /** 削除者 */
+  @Column(name = "deleted_by", length = 50)
+  private String deletedBy;
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/InvalidPersistedOrderException.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/InvalidPersistedOrderException.java
@@ -1,41 +1,31 @@
 package jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order;
 
-/**
- * 永続化済み注文データがドメイン再構築できない場合の例外
- */
+/** 永続化済み注文データがドメイン再構築できない場合の例外 */
 public class InvalidPersistedOrderException extends RuntimeException {
 
-    /**
-     * 永続化済み注文データ不整合時のログ用メッセージテンプレート
-     */
-    private static final String MESSAGE_TEMPLATE = "%s: orderId=%s, orderCode=%s";
+  /** 永続化済み注文データ不整合時のログ用メッセージテンプレート */
+  private static final String MESSAGE_TEMPLATE = "%s: orderId=%s, orderCode=%s";
 
-    /**
-     * コンストラクタ
-     *
-     * @param message メッセージ
-     */
-    private InvalidPersistedOrderException(final String message) {
-        super(message);
-    }
+  /**
+   * コンストラクタ
+   *
+   * @param message メッセージ
+   */
+  private InvalidPersistedOrderException(final String message) {
+    super(message);
+  }
 
-    /**
-     * 永続化済み注文エンティティの識別情報を含む例外を生成する
-     *
-     * @param message        不整合内容を表すメッセージ
-     * @param orderJpaEntity 不整合が検出された注文JPAエンティティ
-     * @return 永続化済み注文データ不整合例外
-     */
-    public static InvalidPersistedOrderException byOrderJpaEntity(
-        final String message,
-        final OrderJpaEntity orderJpaEntity) {
+  /**
+   * 永続化済み注文エンティティの識別情報を含む例外を生成する
+   *
+   * @param message 不整合内容を表すメッセージ
+   * @param orderJpaEntity 不整合が検出された注文JPAエンティティ
+   * @return 永続化済み注文データ不整合例外
+   */
+  public static InvalidPersistedOrderException byOrderJpaEntity(
+      final String message, final OrderJpaEntity orderJpaEntity) {
 
-        return new InvalidPersistedOrderException(
-            MESSAGE_TEMPLATE.formatted(
-                message,
-                orderJpaEntity.getId(),
-                orderJpaEntity.getOrderCode()
-            )
-        );
-    }
+    return new InvalidPersistedOrderException(
+        MESSAGE_TEMPLATE.formatted(message, orderJpaEntity.getId(), orderJpaEntity.getOrderCode()));
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaEntity.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaEntity.java
@@ -1,18 +1,15 @@
 package jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order;
 
 import jakarta.persistence.*;
+import java.time.OffsetDateTime;
+import java.util.UUID;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.BaseAuditJpaEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.time.OffsetDateTime;
-import java.util.UUID;
-
-/**
- * 注文JPAエンティティ
- */
+/** 注文JPAエンティティ */
 @Entity
 @Table(name = "orders")
 @Getter
@@ -20,35 +17,25 @@ import java.util.UUID;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class OrderJpaEntity extends BaseAuditJpaEntity {
 
-    /**
-     * 注文ID
-     */
-    @Id
-    @Column(name = "id", nullable = false, updatable = false)
-    private UUID id;
+  /** 注文ID */
+  @Id
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
 
-    /**
-     * 注文コード
-     */
-    @Column(name = "order_code", nullable = false, length = 20)
-    private String orderCode;
+  /** 注文コード */
+  @Column(name = "order_code", nullable = false, length = 20)
+  private String orderCode;
 
-    /**
-     * 注文日時
-     */
-    @Column(name = "ordered_at", nullable = false)
-    private OffsetDateTime orderedAt;
+  /** 注文日時 */
+  @Column(name = "ordered_at", nullable = false)
+  private OffsetDateTime orderedAt;
 
-    /**
-     * 注文ステータス
-     */
-    @Column(name = "order_status", nullable = false, length = 10)
-    private String orderStatus;
+  /** 注文ステータス */
+  @Column(name = "order_status", nullable = false, length = 10)
+  private String orderStatus;
 
-    /**
-     * バージョン
-     */
-    @Version
-    @Column(name = "version", nullable = false)
-    private Long version;
+  /** バージョン */
+  @Version
+  @Column(name = "version", nullable = false)
+  private Long version;
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaMapper.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaMapper.java
@@ -2,162 +2,135 @@ package jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order;
 
 import jp.co.shimizutdev.phoneorderapi.domain.order.*;
 
-/**
- * 注文JPAマッパー
- */
+/** 注文JPAマッパー */
 public class OrderJpaMapper {
 
-    /**
-     * 永続化済み注文データの注文ID不正時の例外メッセージ
-     */
-    private static final String INVALID_ORDER_ID_MESSAGE = "永続化済み注文データの注文IDが不正です。";
+  /** 永続化済み注文データの注文ID不正時の例外メッセージ */
+  private static final String INVALID_ORDER_ID_MESSAGE = "永続化済み注文データの注文IDが不正です。";
 
-    /**
-     * 永続化済み注文データの注文コード不正時の例外メッセージ
-     */
-    private static final String INVALID_ORDER_CODE_MESSAGE = "永続化済み注文データの注文コードが不正です。";
+  /** 永続化済み注文データの注文コード不正時の例外メッセージ */
+  private static final String INVALID_ORDER_CODE_MESSAGE = "永続化済み注文データの注文コードが不正です。";
 
-    /**
-     * 永続化済み注文データの注文日時不正時の例外メッセージ
-     */
-    private static final String INVALID_ORDERED_AT_MESSAGE = "永続化済み注文データの注文日時が不正です。";
+  /** 永続化済み注文データの注文日時不正時の例外メッセージ */
+  private static final String INVALID_ORDERED_AT_MESSAGE = "永続化済み注文データの注文日時が不正です。";
 
-    /**
-     * 永続化済み注文データの注文ステータス不正時の例外メッセージ
-     */
-    private static final String INVALID_ORDER_STATUS_MESSAGE = "永続化済み注文データの注文ステータスが不正です。";
+  /** 永続化済み注文データの注文ステータス不正時の例外メッセージ */
+  private static final String INVALID_ORDER_STATUS_MESSAGE = "永続化済み注文データの注文ステータスが不正です。";
 
-    /**
-     * 永続化済み注文データのバージョン不正時の例外メッセージ
-     */
-    private static final String INVALID_ORDER_VERSION_MESSAGE = "永続化済み注文データのバージョンが不正です。";
+  /** 永続化済み注文データのバージョン不正時の例外メッセージ */
+  private static final String INVALID_ORDER_VERSION_MESSAGE = "永続化済み注文データのバージョンが不正です。";
 
-    /**
-     * コンストラクタ(インスタンス化を防止)
-     */
-    private OrderJpaMapper() {
+  /** コンストラクタ(インスタンス化を防止) */
+  private OrderJpaMapper() {}
+
+  /**
+   * 注文JPAエンティティを注文へ変換する
+   *
+   * @param orderJpaEntity 注文JPAエンティティ
+   * @return 注文
+   * @throws InvalidPersistedOrderException 永続化済み注文データが不正な場合
+   */
+  public static Order toDomain(final OrderJpaEntity orderJpaEntity) {
+    return Order.reconstruct(
+        toOrderId(orderJpaEntity),
+        toOrderCode(orderJpaEntity),
+        toOrderedAt(orderJpaEntity),
+        toOrderStatus(orderJpaEntity),
+        toVersion(orderJpaEntity));
+  }
+
+  /**
+   * 新規登録用の注文を注文JPAエンティティへ変換する `@Version` の初期値は JPA に採番させるため設定しない
+   *
+   * @param order 注文
+   * @return 注文JPAエンティティ
+   */
+  public static OrderJpaEntity toNewEntity(final Order order) {
+    OrderJpaEntity orderJpaEntity = new OrderJpaEntity();
+    orderJpaEntity.setId(order.getOrderId().getValue());
+    orderJpaEntity.setOrderCode(order.getOrderCode().getValue());
+    orderJpaEntity.setOrderedAt(order.getOrderedAt().getValue());
+    orderJpaEntity.setOrderStatus(order.getOrderStatus().getCode());
+    return orderJpaEntity;
+  }
+
+  /**
+   * 注文IDを再構築する
+   *
+   * @param orderJpaEntity 注文JPAエンティティ
+   * @return 注文ID
+   * @throws InvalidPersistedOrderException 永続化済み注文データの注文IDが不正な場合
+   */
+  private static OrderId toOrderId(final OrderJpaEntity orderJpaEntity) {
+    if (orderJpaEntity.getId() == null) {
+      throw InvalidPersistedOrderException.byOrderJpaEntity(
+          INVALID_ORDER_ID_MESSAGE, orderJpaEntity);
     }
 
-    /**
-     * 注文JPAエンティティを注文へ変換する
-     *
-     * @param orderJpaEntity 注文JPAエンティティ
-     * @return 注文
-     * @throws InvalidPersistedOrderException 永続化済み注文データが不正な場合
-     */
-    public static Order toDomain(final OrderJpaEntity orderJpaEntity) {
-        return Order.reconstruct(
-            toOrderId(orderJpaEntity),
-            toOrderCode(orderJpaEntity),
-            toOrderedAt(orderJpaEntity),
-            toOrderStatus(orderJpaEntity),
-            toVersion(orderJpaEntity)
-        );
+    return OrderId.of(orderJpaEntity.getId());
+  }
+
+  /**
+   * 注文コードを再構築する
+   *
+   * @param orderJpaEntity 注文JPAエンティティ
+   * @return 注文コード
+   * @throws InvalidPersistedOrderException 永続化済み注文データの注文コードが不正な場合
+   */
+  private static OrderCode toOrderCode(final OrderJpaEntity orderJpaEntity) {
+    if (!OrderCode.isValid(orderJpaEntity.getOrderCode())) {
+      throw InvalidPersistedOrderException.byOrderJpaEntity(
+          INVALID_ORDER_CODE_MESSAGE, orderJpaEntity);
     }
 
-    /**
-     * 新規登録用の注文を注文JPAエンティティへ変換する
-     * `@Version` の初期値は JPA に採番させるため設定しない
-     *
-     * @param order 注文
-     * @return 注文JPAエンティティ
-     */
-    public static OrderJpaEntity toNewEntity(final Order order) {
-        OrderJpaEntity orderJpaEntity = new OrderJpaEntity();
-        orderJpaEntity.setId(order.getOrderId().getValue());
-        orderJpaEntity.setOrderCode(order.getOrderCode().getValue());
-        orderJpaEntity.setOrderedAt(order.getOrderedAt().getValue());
-        orderJpaEntity.setOrderStatus(order.getOrderStatus().getCode());
-        return orderJpaEntity;
+    return OrderCode.of(orderJpaEntity.getOrderCode());
+  }
+
+  /**
+   * 注文日時を再構築する
+   *
+   * @param orderJpaEntity 注文JPAエンティティ
+   * @return 注文日時
+   * @throws InvalidPersistedOrderException 永続化済み注文データの注文日時が不正な場合
+   */
+  private static OrderedAt toOrderedAt(final OrderJpaEntity orderJpaEntity) {
+    if (orderJpaEntity.getOrderedAt() == null) {
+      throw InvalidPersistedOrderException.byOrderJpaEntity(
+          INVALID_ORDERED_AT_MESSAGE, orderJpaEntity);
     }
 
-    /**
-     * 注文IDを再構築する
-     *
-     * @param orderJpaEntity 注文JPAエンティティ
-     * @return 注文ID
-     * @throws InvalidPersistedOrderException 永続化済み注文データの注文IDが不正な場合
-     */
-    private static OrderId toOrderId(final OrderJpaEntity orderJpaEntity) {
-        if (orderJpaEntity.getId() == null) {
-            throw InvalidPersistedOrderException.byOrderJpaEntity(
-                INVALID_ORDER_ID_MESSAGE,
-                orderJpaEntity
-            );
-        }
+    return OrderedAt.of(orderJpaEntity.getOrderedAt());
+  }
 
-        return OrderId.of(orderJpaEntity.getId());
+  /**
+   * 注文ステータスを再構築する
+   *
+   * @param orderJpaEntity 注文JPAエンティティ
+   * @return 注文ステータス
+   * @throws InvalidPersistedOrderException 永続化済み注文データの注文ステータスが不正な場合
+   */
+  private static OrderStatus toOrderStatus(final OrderJpaEntity orderJpaEntity) {
+    if (!OrderStatus.isValidCode(orderJpaEntity.getOrderStatus())) {
+      throw InvalidPersistedOrderException.byOrderJpaEntity(
+          INVALID_ORDER_STATUS_MESSAGE, orderJpaEntity);
     }
 
-    /**
-     * 注文コードを再構築する
-     *
-     * @param orderJpaEntity 注文JPAエンティティ
-     * @return 注文コード
-     * @throws InvalidPersistedOrderException 永続化済み注文データの注文コードが不正な場合
-     */
-    private static OrderCode toOrderCode(final OrderJpaEntity orderJpaEntity) {
-        if (!OrderCode.isValid(orderJpaEntity.getOrderCode())) {
-            throw InvalidPersistedOrderException.byOrderJpaEntity(
-                INVALID_ORDER_CODE_MESSAGE,
-                orderJpaEntity
-            );
-        }
+    return OrderStatus.fromCode(orderJpaEntity.getOrderStatus());
+  }
 
-        return OrderCode.of(orderJpaEntity.getOrderCode());
+  /**
+   * バージョンを再構築する
+   *
+   * @param orderJpaEntity 注文JPAエンティティ
+   * @return バージョン
+   * @throws InvalidPersistedOrderException 永続化済み注文データのバージョンが不正な場合
+   */
+  private static Version toVersion(final OrderJpaEntity orderJpaEntity) {
+    if (orderJpaEntity.getVersion() == null || orderJpaEntity.getVersion() < 0) {
+      throw InvalidPersistedOrderException.byOrderJpaEntity(
+          INVALID_ORDER_VERSION_MESSAGE, orderJpaEntity);
     }
 
-    /**
-     * 注文日時を再構築する
-     *
-     * @param orderJpaEntity 注文JPAエンティティ
-     * @return 注文日時
-     * @throws InvalidPersistedOrderException 永続化済み注文データの注文日時が不正な場合
-     */
-    private static OrderedAt toOrderedAt(final OrderJpaEntity orderJpaEntity) {
-        if (orderJpaEntity.getOrderedAt() == null) {
-            throw InvalidPersistedOrderException.byOrderJpaEntity(
-                INVALID_ORDERED_AT_MESSAGE,
-                orderJpaEntity
-            );
-        }
-
-        return OrderedAt.of(orderJpaEntity.getOrderedAt());
-    }
-
-    /**
-     * 注文ステータスを再構築する
-     *
-     * @param orderJpaEntity 注文JPAエンティティ
-     * @return 注文ステータス
-     * @throws InvalidPersistedOrderException 永続化済み注文データの注文ステータスが不正な場合
-     */
-    private static OrderStatus toOrderStatus(final OrderJpaEntity orderJpaEntity) {
-        if (!OrderStatus.isValidCode(orderJpaEntity.getOrderStatus())) {
-            throw InvalidPersistedOrderException.byOrderJpaEntity(
-                INVALID_ORDER_STATUS_MESSAGE,
-                orderJpaEntity
-            );
-        }
-
-        return OrderStatus.fromCode(orderJpaEntity.getOrderStatus());
-    }
-
-    /**
-     * バージョンを再構築する
-     *
-     * @param orderJpaEntity 注文JPAエンティティ
-     * @return バージョン
-     * @throws InvalidPersistedOrderException 永続化済み注文データのバージョンが不正な場合
-     */
-    private static Version toVersion(final OrderJpaEntity orderJpaEntity) {
-        if (orderJpaEntity.getVersion() == null || orderJpaEntity.getVersion() < 0) {
-            throw InvalidPersistedOrderException.byOrderJpaEntity(
-                INVALID_ORDER_VERSION_MESSAGE,
-                orderJpaEntity
-            );
-        }
-
-        return Version.of(orderJpaEntity.getVersion());
-    }
+    return Version.of(orderJpaEntity.getVersion());
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaRepository.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/persistence/order/OrderJpaRepository.java
@@ -1,38 +1,35 @@
 package jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order;
 
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.Optional;
-import java.util.UUID;
-
-/**
- * 注文JPAリポジトリ
- */
+/** 注文JPAリポジトリ */
 public interface OrderJpaRepository extends JpaRepository<OrderJpaEntity, UUID> {
 
-    /**
-     * 注文コードで注文JPAエンティティを取得
-     *
-     * @param orderCode 注文コード
-     * @return 注文JPAエンティティ。存在しない場合は空の Optional
-     */
-    Optional<OrderJpaEntity> findByOrderCode(String orderCode);
+  /**
+   * 注文コードで注文JPAエンティティを取得
+   *
+   * @param orderCode 注文コード
+   * @return 注文JPAエンティティ。存在しない場合は空の Optional
+   */
+  Optional<OrderJpaEntity> findByOrderCode(String orderCode);
 
-    /**
-     * 注文IDとバージョンで注文JPAエンティティを取得する
-     *
-     * @param id      注文ID
-     * @param version バージョン
-     * @return 注文JPAエンティティ。存在しない場合は空の Optional
-     */
-    Optional<OrderJpaEntity> findByIdAndVersion(UUID id, Long version);
+  /**
+   * 注文IDとバージョンで注文JPAエンティティを取得する
+   *
+   * @param id 注文ID
+   * @param version バージョン
+   * @return 注文JPAエンティティ。存在しない場合は空の Optional
+   */
+  Optional<OrderJpaEntity> findByIdAndVersion(UUID id, Long version);
 
-    /**
-     * DB の注文コード採番関数を呼び出す
-     *
-     * @return 採番済み注文コード
-     */
-    @Query(value = "select next_order_code()", nativeQuery = true)
-    String nextOrderCode();
+  /**
+   * DB の注文コード採番関数を呼び出す
+   *
+   * @return 採番済み注文コード
+   */
+  @Query(value = "select next_order_code()", nativeQuery = true)
+  String nextOrderCode();
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/repository/order/OrderRepositoryImpl.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/infrastructure/repository/order/OrderRepositoryImpl.java
@@ -2,6 +2,8 @@ package jp.co.shimizutdev.phoneorderapi.infrastructure.repository.order;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import java.util.Optional;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PageResult;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PagingCondition;
 import jp.co.shimizutdev.phoneorderapi.domain.order.Order;
@@ -18,104 +20,89 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.Optional;
-
-/**
- * 注文リポジトリ実装
- */
+/** 注文リポジトリ実装 */
 @Repository
 @RequiredArgsConstructor
 public class OrderRepositoryImpl implements OrderRepository {
 
-    /**
-     * 注文JPAリポジトリ
-     */
-    private final OrderJpaRepository orderJpaRepository;
+  /** 注文JPAリポジトリ */
+  private final OrderJpaRepository orderJpaRepository;
 
-    /**
-     * エンティティマネージャ
-     */
-    @PersistenceContext
-    private EntityManager entityManager;
+  /** エンティティマネージャ */
+  @PersistenceContext private EntityManager entityManager;
 
-    /**
-     * 注文一覧を取得する
-     *
-     * @param pagingCondition ページング条件
-     * @return 注文日時降順、同一日時は注文コード降順のページング済み注文一覧。存在しない場合または範囲外ページの場合は空のページ
-     * @throws InvalidPersistedOrderException 永続化済み注文データが不正な場合
-     */
-    @Override
-    public PageResult<Order> findAll(final PagingCondition pagingCondition) {
-        Page<OrderJpaEntity> page = orderJpaRepository.findAll(
+  /**
+   * 注文一覧を取得する
+   *
+   * @param pagingCondition ページング条件
+   * @return 注文日時降順、同一日時は注文コード降順のページング済み注文一覧。存在しない場合または範囲外ページの場合は空のページ
+   * @throws InvalidPersistedOrderException 永続化済み注文データが不正な場合
+   */
+  @Override
+  public PageResult<Order> findAll(final PagingCondition pagingCondition) {
+    Page<OrderJpaEntity> page =
+        orderJpaRepository.findAll(
             PageRequest.of(
                 pagingCondition.page(),
                 pagingCondition.size(),
                 Sort.by(Sort.Direction.DESC, "orderedAt")
-                    .and(Sort.by(Sort.Direction.DESC, "orderCode"))
-            )
-        );
+                    .and(Sort.by(Sort.Direction.DESC, "orderCode"))));
 
-        List<Order> orders = page.getContent().stream()
-            .map(OrderJpaMapper::toDomain)
-            .toList();
+    List<Order> orders = page.getContent().stream().map(OrderJpaMapper::toDomain).toList();
 
-        return new PageResult<>(
-            orders,
-            pagingCondition.page(),
-            pagingCondition.size(),
-            page.getTotalElements(),
-            page.getTotalPages()
-        );
-    }
+    return new PageResult<>(
+        orders,
+        pagingCondition.page(),
+        pagingCondition.size(),
+        page.getTotalElements(),
+        page.getTotalPages());
+  }
 
-    /**
-     * 注文コードで注文を取得する
-     *
-     * @param orderCode 注文コード
-     * @return 注文。存在しない場合は空の Optional
-     * @throws InvalidPersistedOrderException 永続化済み注文データが不正な場合
-     */
-    @Override
-    public Optional<Order> findByOrderCode(final OrderCode orderCode) {
-        return orderJpaRepository.findByOrderCode(orderCode.getValue())
-            .map(OrderJpaMapper::toDomain);
-    }
+  /**
+   * 注文コードで注文を取得する
+   *
+   * @param orderCode 注文コード
+   * @return 注文。存在しない場合は空の Optional
+   * @throws InvalidPersistedOrderException 永続化済み注文データが不正な場合
+   */
+  @Override
+  public Optional<Order> findByOrderCode(final OrderCode orderCode) {
+    return orderJpaRepository.findByOrderCode(orderCode.getValue()).map(OrderJpaMapper::toDomain);
+  }
 
-    /**
-     * 注文を登録する
-     *
-     * @param order 注文
-     * @return 注文
-     * @throws InvalidPersistedOrderException 登録後の永続化済み注文データが不正な場合
-     */
-    @Override
-    public Order create(final Order order) {
-        OrderJpaEntity orderJpaEntity = OrderJpaMapper.toNewEntity(order);
-        entityManager.persist(orderJpaEntity);
-        entityManager.flush();
-        return OrderJpaMapper.toDomain(orderJpaEntity);
-    }
+  /**
+   * 注文を登録する
+   *
+   * @param order 注文
+   * @return 注文
+   * @throws InvalidPersistedOrderException 登録後の永続化済み注文データが不正な場合
+   */
+  @Override
+  public Order create(final Order order) {
+    OrderJpaEntity orderJpaEntity = OrderJpaMapper.toNewEntity(order);
+    entityManager.persist(orderJpaEntity);
+    entityManager.flush();
+    return OrderJpaMapper.toDomain(orderJpaEntity);
+  }
 
-    /**
-     * 注文を更新する
-     *
-     * @param order 注文
-     * @return 注文
-     * @throws OrderVersionConflictException 更新対象の注文バージョンが一致しない場合
-     * @throws InvalidPersistedOrderException 更新後の永続化済み注文データが不正な場合
-     */
-    @Override
-    public Order update(final Order order) {
-        OrderJpaEntity orderJpaEntity = orderJpaRepository.findByIdAndVersion(
-                order.getOrderId().getValue(),
-                order.getVersion().getValue())
+  /**
+   * 注文を更新する
+   *
+   * @param order 注文
+   * @return 注文
+   * @throws OrderVersionConflictException 更新対象の注文バージョンが一致しない場合
+   * @throws InvalidPersistedOrderException 更新後の永続化済み注文データが不正な場合
+   */
+  @Override
+  public Order update(final Order order) {
+    OrderJpaEntity orderJpaEntity =
+        orderJpaRepository
+            .findByIdAndVersion(order.getOrderId().getValue(), order.getVersion().getValue())
             .orElseThrow(() -> OrderVersionConflictException.byOrderForUpdate(order));
 
-        orderJpaEntity.setOrderStatus(order.getOrderStatus().getCode());
-        entityManager.flush();
+    orderJpaEntity.setOrderStatus(order.getOrderStatus().getCode());
+    entityManager.flush();
 
-        return OrderJpaMapper.toDomain(orderJpaEntity);
-    }
+    return OrderJpaMapper.toDomain(orderJpaEntity);
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiErrorMessages.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiErrorMessages.java
@@ -1,48 +1,29 @@
 package jp.co.shimizutdev.phoneorderapi.presentation.error;
 
-/**
- * APIエラーメッセージ
- */
+/** APIエラーメッセージ */
 public final class ApiErrorMessages {
 
-    /**
-     * バリデーションエラー時のメッセージ
-     */
-    public static final String VALIDATION_ERROR = "入力値が不正です。";
+  /** バリデーションエラー時のメッセージ */
+  public static final String VALIDATION_ERROR = "入力値が不正です。";
 
-    /**
-     * リクエストボディの形式が不正な場合のメッセージ
-     */
-    public static final String INVALID_REQUEST_BODY = "リクエストボディの形式が不正です。";
+  /** リクエストボディの形式が不正な場合のメッセージ */
+  public static final String INVALID_REQUEST_BODY = "リクエストボディの形式が不正です。";
 
-    /**
-     * 監査ユーザーが不正な場合のメッセージ
-     */
-    public static final String INVALID_AUDITOR = "監査ユーザーは50文字以内で指定してください。";
+  /** 監査ユーザーが不正な場合のメッセージ */
+  public static final String INVALID_AUDITOR = "監査ユーザーは50文字以内で指定してください。";
 
-    /**
-     * サーバー内部でエラーが発生した場合のメッセージ
-     */
-    public static final String INTERNAL_SERVER_ERROR = "サーバー内部でエラーが発生しました。";
+  /** サーバー内部でエラーが発生した場合のメッセージ */
+  public static final String INTERNAL_SERVER_ERROR = "サーバー内部でエラーが発生しました。";
 
-    /**
-     * 注文が見つからない場合のメッセージ
-     */
-    public static final String ORDER_NOT_FOUND = "注文が見つかりません。";
+  /** 注文が見つからない場合のメッセージ */
+  public static final String ORDER_NOT_FOUND = "注文が見つかりません。";
 
-    /**
-     * 注文をキャンセルできない場合のメッセージ
-     */
-    public static final String ORDER_CANNOT_BE_CANCELLED = "注文をキャンセルできません。";
+  /** 注文をキャンセルできない場合のメッセージ */
+  public static final String ORDER_CANNOT_BE_CANCELLED = "注文をキャンセルできません。";
 
-    /**
-     * 注文の楽観的ロック競合時のメッセージ
-     */
-    public static final String ORDER_VERSION_CONFLICT = "注文が他の更新で変更されました。最新データを取得してから再実行してください。";
+  /** 注文の楽観的ロック競合時のメッセージ */
+  public static final String ORDER_VERSION_CONFLICT = "注文が他の更新で変更されました。最新データを取得してから再実行してください。";
 
-    /**
-     * コンストラクタ(インスタンス化を防止)
-     */
-    private ApiErrorMessages() {
-    }
+  /** コンストラクタ(インスタンス化を防止) */
+  private ApiErrorMessages() {}
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiErrorResponse.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiErrorResponse.java
@@ -6,11 +6,11 @@ import java.util.List;
 /**
  * APIエラーレスポンス
  *
- * @param timestamp        エラー発生日時
- * @param status           HTTP ステータスコード
- * @param error            エラーコード
- * @param message          エラーメッセージ
- * @param path             リクエストパス
+ * @param timestamp エラー発生日時
+ * @param status HTTP ステータスコード
+ * @param error エラーコード
+ * @param message エラーメッセージ
+ * @param path リクエストパス
  * @param validationErrors バリデーションエラー一覧
  */
 public record ApiErrorResponse(
@@ -19,17 +19,14 @@ public record ApiErrorResponse(
     String error,
     String message,
     String path,
-    List<ApiValidationError> validationErrors
-) {
+    List<ApiValidationError> validationErrors) {
 
-    /**
-     * コンストラクタ
-     *
-     * <p>バリデーションエラー一覧は null を空リストに補正し、不変リストとして保持する</p>
-     */
-    public ApiErrorResponse {
-        validationErrors = validationErrors == null
-            ? List.of()
-            : List.copyOf(validationErrors);
-    }
+  /**
+   * コンストラクタ
+   *
+   * <p>バリデーションエラー一覧は null を空リストに補正し、不変リストとして保持する
+   */
+  public ApiErrorResponse {
+    validationErrors = validationErrors == null ? List.of() : List.copyOf(validationErrors);
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandler.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandler.java
@@ -4,6 +4,11 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
 import jakarta.validation.Path;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.StreamSupport;
 import jp.co.shimizutdev.phoneorderapi.domain.order.OrderCannotBeCancelledException;
 import jp.co.shimizutdev.phoneorderapi.domain.order.OrderNotFoundException;
 import jp.co.shimizutdev.phoneorderapi.domain.order.OrderVersionConflictException;
@@ -21,429 +26,351 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-import java.time.OffsetDateTime;
-import java.util.List;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.StreamSupport;
-
-/**
- * API例外ハンドラ
- */
+/** API例外ハンドラ */
 @RestControllerAdvice
 public class ApiExceptionHandler {
 
-    /**
-     * ログ
-     */
-    private static final Logger log = LoggerFactory.getLogger(ApiExceptionHandler.class);
+  /** ログ */
+  private static final Logger log = LoggerFactory.getLogger(ApiExceptionHandler.class);
 
-    /**
-     * リクエストボディの Bean Validation エラーを 400 Bad Request に変換する
-     *
-     * @param ex      バリデーション例外
-     * @param request HTTP リクエスト
-     * @return バリデーションエラーを表す API エラーレスポンス
-     */
-    @SuppressWarnings("unused")
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(
-        final MethodArgumentNotValidException ex,
-        final HttpServletRequest request) {
+  /**
+   * リクエストボディの Bean Validation エラーを 400 Bad Request に変換する
+   *
+   * @param ex バリデーション例外
+   * @param request HTTP リクエスト
+   * @return バリデーションエラーを表す API エラーレスポンス
+   */
+  @SuppressWarnings("unused")
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiErrorResponse> handleMethodArgumentNotValidException(
+      final MethodArgumentNotValidException ex, final HttpServletRequest request) {
 
-        logHandledException(ApiErrorMessages.VALIDATION_ERROR, request, ex);
+    logHandledException(ApiErrorMessages.VALIDATION_ERROR, request, ex);
 
-        return buildErrorResponse(
-            HttpStatus.BAD_REQUEST,
-            ApiErrorMessages.VALIDATION_ERROR,
-            request,
-            ex.getBindingResult()
-                .getFieldErrors()
-                .stream()
-                .map(this::toValidationError)
-                .toList()
-        );
+    return buildErrorResponse(
+        HttpStatus.BAD_REQUEST,
+        ApiErrorMessages.VALIDATION_ERROR,
+        request,
+        ex.getBindingResult().getFieldErrors().stream().map(this::toValidationError).toList());
+  }
+
+  /**
+   * パラメータなどの制約違反を 400 Bad Request に変換する
+   *
+   * @param ex 制約違反例外
+   * @param request HTTP リクエスト
+   * @return バリデーションエラーを表す API エラーレスポンス
+   */
+  @SuppressWarnings("unused")
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<ApiErrorResponse> handleConstraintViolationException(
+      final ConstraintViolationException ex, final HttpServletRequest request) {
+
+    logHandledException(ApiErrorMessages.VALIDATION_ERROR, request, ex);
+
+    return buildErrorResponse(
+        HttpStatus.BAD_REQUEST,
+        ApiErrorMessages.VALIDATION_ERROR,
+        request,
+        ex.getConstraintViolations().stream().map(this::toValidationError).toList());
+  }
+
+  /**
+   * 不正な引数を表す {@link IllegalArgumentException} を 400 Bad Request に変換する
+   *
+   * @param ex 不正引数例外
+   * @param request HTTP リクエスト
+   * @return API エラーレスポンス
+   */
+  @SuppressWarnings("unused")
+  @ExceptionHandler(IllegalArgumentException.class)
+  public ResponseEntity<ApiErrorResponse> handleIllegalArgumentException(
+      final IllegalArgumentException ex, final HttpServletRequest request) {
+
+    logHandledException(
+        resolveMessage(ex.getMessage(), ApiErrorMessages.VALIDATION_ERROR), request, ex);
+
+    return buildErrorResponse(
+        HttpStatus.BAD_REQUEST, ApiErrorMessages.VALIDATION_ERROR, request, List.of());
+  }
+
+  /**
+   * JSON の構文不正や型不一致を 400 Bad Request に変換する
+   *
+   * @param ex メッセージ変換例外
+   * @param request HTTP リクエスト
+   * @return API エラーレスポンス
+   */
+  @SuppressWarnings("unused")
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ResponseEntity<ApiErrorResponse> handleHttpMessageNotReadableException(
+      final HttpMessageNotReadableException ex, final HttpServletRequest request) {
+
+    logHandledException(ApiErrorMessages.INVALID_REQUEST_BODY, request, ex);
+
+    return buildErrorResponse(
+        HttpStatus.BAD_REQUEST, ApiErrorMessages.INVALID_REQUEST_BODY, request, List.of());
+  }
+
+  /**
+   * 監査ユーザー不正例外を 400 Bad Request に変換する
+   *
+   * @param ex 監査ユーザー不正例外
+   * @param request HTTP リクエスト
+   * @return API エラーレスポンス
+   */
+  @SuppressWarnings("unused")
+  @ExceptionHandler(InvalidAuditorException.class)
+  public ResponseEntity<ApiErrorResponse> handleInvalidAuditorException(
+      final InvalidAuditorException ex, final HttpServletRequest request) {
+
+    logHandledException(ApiErrorMessages.INVALID_AUDITOR, request, ex);
+
+    return buildErrorResponse(
+        HttpStatus.BAD_REQUEST, ApiErrorMessages.INVALID_AUDITOR, request, List.of());
+  }
+
+  /**
+   * 注文キャンセル不可の業務例外を 409 Conflict に変換する
+   *
+   * @param ex 注文キャンセル不可例外
+   * @param request HTTP リクエスト
+   * @return API エラーレスポンス
+   */
+  @SuppressWarnings("unused")
+  @ExceptionHandler(OrderCannotBeCancelledException.class)
+  public ResponseEntity<ApiErrorResponse> handleOrderCannotBeCancelledException(
+      final OrderCannotBeCancelledException ex, final HttpServletRequest request) {
+
+    logHandledException(ApiErrorMessages.ORDER_CANNOT_BE_CANCELLED, request, ex);
+
+    return buildErrorResponse(
+        HttpStatus.CONFLICT, ApiErrorMessages.ORDER_CANNOT_BE_CANCELLED, request, List.of());
+  }
+
+  /**
+   * 注文の楽観ロック競合を 409 Conflict に変換する
+   *
+   * @param ex 楽観ロック競合例外
+   * @param request HTTP リクエスト
+   * @return API エラーレスポンス
+   */
+  @SuppressWarnings("unused")
+  @ExceptionHandler({
+    OrderVersionConflictException.class,
+    ObjectOptimisticLockingFailureException.class
+  })
+  public ResponseEntity<ApiErrorResponse> handleOptimisticLockException(
+      final RuntimeException ex, final HttpServletRequest request) {
+
+    logHandledException(ApiErrorMessages.ORDER_VERSION_CONFLICT, request, ex);
+
+    return buildErrorResponse(
+        HttpStatus.CONFLICT, ApiErrorMessages.ORDER_VERSION_CONFLICT, request, List.of());
+  }
+
+  /**
+   * 永続化済みデータ不整合を 500 Internal Server Error に変換する
+   *
+   * @param ex 永続化済みデータ不整合例外
+   * @param request HTTP リクエスト
+   * @return API エラーレスポンス
+   */
+  @SuppressWarnings("unused")
+  @ExceptionHandler(InvalidPersistedOrderException.class)
+  public ResponseEntity<ApiErrorResponse> handleInvalidPersistedOrderException(
+      final InvalidPersistedOrderException ex, final HttpServletRequest request) {
+
+    logHandledUnexpectedException(
+        resolveMessage(ex.getMessage(), ApiErrorMessages.INTERNAL_SERVER_ERROR), request, ex);
+
+    return buildErrorResponse(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        ApiErrorMessages.INTERNAL_SERVER_ERROR,
+        request,
+        List.of());
+  }
+
+  /**
+   * 注文未存在例外を 404 Not Found に変換する
+   *
+   * @param ex 注文未存在例外
+   * @param request HTTP リクエスト
+   * @return API エラーレスポンス
+   */
+  @SuppressWarnings("unused")
+  @ExceptionHandler(OrderNotFoundException.class)
+  public ResponseEntity<ApiErrorResponse> handleOrderNotFoundException(
+      final OrderNotFoundException ex, final HttpServletRequest request) {
+
+    logHandledException(ApiErrorMessages.ORDER_NOT_FOUND, request, ex);
+
+    return buildErrorResponse(
+        HttpStatus.NOT_FOUND, ApiErrorMessages.ORDER_NOT_FOUND, request, List.of());
+  }
+
+  /**
+   * 想定外例外を 500 Internal Server Error に変換し、詳細はサーバーログへ記録する
+   *
+   * @param ex 想定外例外
+   * @param request HTTP リクエスト
+   * @return API エラーレスポンス
+   */
+  @SuppressWarnings("unused")
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ApiErrorResponse> handleUnexpectedException(
+      final Exception ex, final HttpServletRequest request) {
+
+    logHandledUnexpectedException(ApiErrorMessages.INTERNAL_SERVER_ERROR, request, ex);
+
+    return buildErrorResponse(
+        HttpStatus.INTERNAL_SERVER_ERROR,
+        ApiErrorMessages.INTERNAL_SERVER_ERROR,
+        request,
+        List.of());
+  }
+
+  /**
+   * フィールド単位のバリデーションエラーを API 用のエラー表現へ変換する
+   *
+   * @param fieldError フィールドエラー
+   * @return API 用バリデーションエラー
+   */
+  private ApiValidationError toValidationError(final FieldError fieldError) {
+    return new ApiValidationError(
+        fieldError.getField(),
+        resolveMessage(fieldError.getDefaultMessage(), ApiErrorMessages.VALIDATION_ERROR));
+  }
+
+  /**
+   * 制約違反を API 用のエラー表現へ変換する
+   *
+   * @param violation 制約違反
+   * @return API 用バリデーションエラー
+   */
+  private ApiValidationError toValidationError(final ConstraintViolation<?> violation) {
+    return new ApiValidationError(
+        extractViolationField(violation),
+        resolveMessage(violation.getMessage(), ApiErrorMessages.VALIDATION_ERROR));
+  }
+
+  /**
+   * 制約違反のプロパティパスからクライアントへ返却する項目名を抽出する
+   *
+   * @param violation 制約違反
+   * @return 項目名
+   */
+  private String extractViolationField(final ConstraintViolation<?> violation) {
+    return StreamSupport.stream(violation.getPropertyPath().spliterator(), false)
+        .map(Path.Node::getName)
+        .filter(Objects::nonNull)
+        .reduce((first, second) -> second)
+        .orElse(violation.getPropertyPath().toString());
+  }
+
+  /**
+   * メッセージが null または空の場合にデフォルトメッセージへ置き換える
+   *
+   * @param message 変換元メッセージ
+   * @param defaultMessage デフォルトメッセージ
+   * @return メッセージ
+   */
+  private String resolveMessage(final String message, final String defaultMessage) {
+    return message != null && !message.isBlank() ? message : defaultMessage;
+  }
+
+  /**
+   * ハンドリング済み例外をデバッグログに出力する
+   *
+   * @param message ログメッセージ
+   * @param request HTTP リクエスト
+   * @param ex 例外
+   */
+  private void logHandledException(
+      final String message, final HttpServletRequest request, final Exception ex) {
+
+    if (log.isDebugEnabled()) {
+      log.debug(
+          "path={}, message={}, exceptionMessage={}",
+          request.getRequestURI(),
+          message,
+          resolveMessage(ex.getMessage(), message),
+          ex);
     }
+  }
 
-    /**
-     * パラメータなどの制約違反を 400 Bad Request に変換する
-     *
-     * @param ex      制約違反例外
-     * @param request HTTP リクエスト
-     * @return バリデーションエラーを表す API エラーレスポンス
-     */
-    @SuppressWarnings("unused")
-    @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<ApiErrorResponse> handleConstraintViolationException(
-        final ConstraintViolationException ex,
-        final HttpServletRequest request) {
+  /**
+   * 想定外またはサーバー内部例外をエラーログに出力する
+   *
+   * @param message ログメッセージ
+   * @param request HTTP リクエスト
+   * @param ex 例外
+   */
+  private void logHandledUnexpectedException(
+      final String message, final HttpServletRequest request, final Exception ex) {
 
-        logHandledException(ApiErrorMessages.VALIDATION_ERROR, request, ex);
-
-        return buildErrorResponse(
-            HttpStatus.BAD_REQUEST,
-            ApiErrorMessages.VALIDATION_ERROR,
-            request,
-            ex.getConstraintViolations()
-                .stream()
-                .map(this::toValidationError)
-                .toList()
-        );
+    if (log.isErrorEnabled()) {
+      log.error(
+          "path={}, message={}, exceptionMessage={}",
+          request.getRequestURI(),
+          message,
+          resolveMessage(ex.getMessage(), message),
+          ex);
     }
+  }
 
-    /**
-     * 不正な引数を表す {@link IllegalArgumentException} を 400 Bad Request に変換する
-     *
-     * @param ex      不正引数例外
-     * @param request HTTP リクエスト
-     * @return API エラーレスポンス
-     */
-    @SuppressWarnings("unused")
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ApiErrorResponse> handleIllegalArgumentException(
-        final IllegalArgumentException ex,
-        final HttpServletRequest request) {
+  /**
+   * 指定したステータスとメッセージから統一形式のエラーレスポンスを組み立てる
+   *
+   * @param statusCode HTTP ステータス
+   * @param message エラーメッセージ
+   * @param request HTTP リクエスト
+   * @param validationErrors バリデーションエラー一覧
+   * @return API エラーレスポンス
+   */
+  private ResponseEntity<ApiErrorResponse> buildErrorResponse(
+      final HttpStatusCode statusCode,
+      final String message,
+      final HttpServletRequest request,
+      final List<ApiValidationError> validationErrors) {
 
-        logHandledException(
-            resolveMessage(ex.getMessage(), ApiErrorMessages.VALIDATION_ERROR),
-            request,
-            ex
-        );
+    return ResponseEntity.status(statusCode)
+        .body(createErrorResponse(statusCode, message, request, validationErrors));
+  }
 
-        return buildErrorResponse(
-            HttpStatus.BAD_REQUEST,
-            ApiErrorMessages.VALIDATION_ERROR,
-            request,
-            List.of()
-        );
-    }
+  /**
+   * エラーレスポンス本体を生成する
+   *
+   * @param statusCode HTTP ステータス
+   * @param message エラーメッセージ
+   * @param request HTTP リクエスト
+   * @param validationErrors バリデーションエラー一覧
+   * @return エラーレスポンス本体
+   */
+  private ApiErrorResponse createErrorResponse(
+      final HttpStatusCode statusCode,
+      final String message,
+      final HttpServletRequest request,
+      final List<ApiValidationError> validationErrors) {
 
-    /**
-     * JSON の構文不正や型不一致を 400 Bad Request に変換する
-     *
-     * @param ex      メッセージ変換例外
-     * @param request HTTP リクエスト
-     * @return API エラーレスポンス
-     */
-    @SuppressWarnings("unused")
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ApiErrorResponse> handleHttpMessageNotReadableException(
-        final HttpMessageNotReadableException ex,
-        final HttpServletRequest request) {
+    return new ApiErrorResponse(
+        OffsetDateTime.now(),
+        statusCode.value(),
+        resolveErrorCode(statusCode),
+        message,
+        request.getRequestURI(),
+        validationErrors);
+  }
 
-        logHandledException(ApiErrorMessages.INVALID_REQUEST_BODY, request, ex);
-
-        return buildErrorResponse(
-            HttpStatus.BAD_REQUEST,
-            ApiErrorMessages.INVALID_REQUEST_BODY,
-            request,
-            List.of()
-        );
-    }
-
-    /**
-     * 監査ユーザー不正例外を 400 Bad Request に変換する
-     *
-     * @param ex      監査ユーザー不正例外
-     * @param request HTTP リクエスト
-     * @return API エラーレスポンス
-     */
-    @SuppressWarnings("unused")
-    @ExceptionHandler(InvalidAuditorException.class)
-    public ResponseEntity<ApiErrorResponse> handleInvalidAuditorException(
-        final InvalidAuditorException ex,
-        final HttpServletRequest request) {
-
-        logHandledException(ApiErrorMessages.INVALID_AUDITOR, request, ex);
-
-        return buildErrorResponse(
-            HttpStatus.BAD_REQUEST,
-            ApiErrorMessages.INVALID_AUDITOR,
-            request,
-            List.of()
-        );
-    }
-
-    /**
-     * 注文キャンセル不可の業務例外を 409 Conflict に変換する
-     *
-     * @param ex      注文キャンセル不可例外
-     * @param request HTTP リクエスト
-     * @return API エラーレスポンス
-     */
-    @SuppressWarnings("unused")
-    @ExceptionHandler(OrderCannotBeCancelledException.class)
-    public ResponseEntity<ApiErrorResponse> handleOrderCannotBeCancelledException(
-        final OrderCannotBeCancelledException ex,
-        final HttpServletRequest request) {
-
-        logHandledException(ApiErrorMessages.ORDER_CANNOT_BE_CANCELLED, request, ex);
-
-        return buildErrorResponse(
-            HttpStatus.CONFLICT,
-            ApiErrorMessages.ORDER_CANNOT_BE_CANCELLED,
-            request,
-            List.of()
-        );
-    }
-
-    /**
-     * 注文の楽観ロック競合を 409 Conflict に変換する
-     *
-     * @param ex      楽観ロック競合例外
-     * @param request HTTP リクエスト
-     * @return API エラーレスポンス
-     */
-    @SuppressWarnings("unused")
-    @ExceptionHandler({OrderVersionConflictException.class, ObjectOptimisticLockingFailureException.class})
-    public ResponseEntity<ApiErrorResponse> handleOptimisticLockException(
-        final RuntimeException ex,
-        final HttpServletRequest request) {
-
-        logHandledException(ApiErrorMessages.ORDER_VERSION_CONFLICT, request, ex);
-
-        return buildErrorResponse(
-            HttpStatus.CONFLICT,
-            ApiErrorMessages.ORDER_VERSION_CONFLICT,
-            request,
-            List.of()
-        );
-    }
-
-    /**
-     * 永続化済みデータ不整合を 500 Internal Server Error に変換する
-     *
-     * @param ex      永続化済みデータ不整合例外
-     * @param request HTTP リクエスト
-     * @return API エラーレスポンス
-     */
-    @SuppressWarnings("unused")
-    @ExceptionHandler(InvalidPersistedOrderException.class)
-    public ResponseEntity<ApiErrorResponse> handleInvalidPersistedOrderException(
-        final InvalidPersistedOrderException ex,
-        final HttpServletRequest request) {
-
-        logHandledUnexpectedException(
-            resolveMessage(ex.getMessage(), ApiErrorMessages.INTERNAL_SERVER_ERROR),
-            request,
-            ex
-        );
-
-        return buildErrorResponse(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            ApiErrorMessages.INTERNAL_SERVER_ERROR,
-            request,
-            List.of()
-        );
-    }
-
-    /**
-     * 注文未存在例外を 404 Not Found に変換する
-     *
-     * @param ex      注文未存在例外
-     * @param request HTTP リクエスト
-     * @return API エラーレスポンス
-     */
-    @SuppressWarnings("unused")
-    @ExceptionHandler(OrderNotFoundException.class)
-    public ResponseEntity<ApiErrorResponse> handleOrderNotFoundException(
-        final OrderNotFoundException ex,
-        final HttpServletRequest request) {
-
-        logHandledException(ApiErrorMessages.ORDER_NOT_FOUND, request, ex);
-
-        return buildErrorResponse(
-            HttpStatus.NOT_FOUND,
-            ApiErrorMessages.ORDER_NOT_FOUND,
-            request,
-            List.of()
-        );
-    }
-
-    /**
-     * 想定外例外を 500 Internal Server Error に変換し、詳細はサーバーログへ記録する
-     *
-     * @param ex      想定外例外
-     * @param request HTTP リクエスト
-     * @return API エラーレスポンス
-     */
-    @SuppressWarnings("unused")
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiErrorResponse> handleUnexpectedException(
-        final Exception ex,
-        final HttpServletRequest request) {
-
-        logHandledUnexpectedException(
-            ApiErrorMessages.INTERNAL_SERVER_ERROR,
-            request,
-            ex
-        );
-
-        return buildErrorResponse(
-            HttpStatus.INTERNAL_SERVER_ERROR,
-            ApiErrorMessages.INTERNAL_SERVER_ERROR,
-            request,
-            List.of()
-        );
-    }
-
-    /**
-     * フィールド単位のバリデーションエラーを API 用のエラー表現へ変換する
-     *
-     * @param fieldError フィールドエラー
-     * @return API 用バリデーションエラー
-     */
-    private ApiValidationError toValidationError(final FieldError fieldError) {
-        return new ApiValidationError(
-            fieldError.getField(),
-            resolveMessage(fieldError.getDefaultMessage(), ApiErrorMessages.VALIDATION_ERROR)
-        );
-    }
-
-    /**
-     * 制約違反を API 用のエラー表現へ変換する
-     *
-     * @param violation 制約違反
-     * @return API 用バリデーションエラー
-     */
-    private ApiValidationError toValidationError(final ConstraintViolation<?> violation) {
-        return new ApiValidationError(
-            extractViolationField(violation),
-            resolveMessage(violation.getMessage(), ApiErrorMessages.VALIDATION_ERROR)
-        );
-    }
-
-    /**
-     * 制約違反のプロパティパスからクライアントへ返却する項目名を抽出する
-     *
-     * @param violation 制約違反
-     * @return 項目名
-     */
-    private String extractViolationField(final ConstraintViolation<?> violation) {
-        return StreamSupport.stream(violation.getPropertyPath().spliterator(), false)
-            .map(Path.Node::getName)
-            .filter(Objects::nonNull)
-            .reduce((first, second) -> second)
-            .orElse(violation.getPropertyPath().toString());
-    }
-
-    /**
-     * メッセージが null または空の場合にデフォルトメッセージへ置き換える
-     *
-     * @param message        変換元メッセージ
-     * @param defaultMessage デフォルトメッセージ
-     * @return メッセージ
-     */
-    private String resolveMessage(final String message, final String defaultMessage) {
-        return message != null && !message.isBlank()
-            ? message
-            : defaultMessage;
-    }
-
-    /**
-     * ハンドリング済み例外をデバッグログに出力する
-     *
-     * @param message ログメッセージ
-     * @param request HTTP リクエスト
-     * @param ex      例外
-     */
-    private void logHandledException(
-        final String message,
-        final HttpServletRequest request,
-        final Exception ex) {
-
-        if (log.isDebugEnabled()) {
-            log.debug(
-                "path={}, message={}, exceptionMessage={}",
-                request.getRequestURI(),
-                message,
-                resolveMessage(ex.getMessage(), message),
-                ex
-            );
-        }
-    }
-
-    /**
-     * 想定外またはサーバー内部例外をエラーログに出力する
-     *
-     * @param message ログメッセージ
-     * @param request HTTP リクエスト
-     * @param ex      例外
-     */
-    private void logHandledUnexpectedException(
-        final String message,
-        final HttpServletRequest request,
-        final Exception ex) {
-
-        if (log.isErrorEnabled()) {
-            log.error(
-                "path={}, message={}, exceptionMessage={}",
-                request.getRequestURI(),
-                message,
-                resolveMessage(ex.getMessage(), message),
-                ex
-            );
-        }
-    }
-
-    /**
-     * 指定したステータスとメッセージから統一形式のエラーレスポンスを組み立てる
-     *
-     * @param statusCode       HTTP ステータス
-     * @param message          エラーメッセージ
-     * @param request          HTTP リクエスト
-     * @param validationErrors バリデーションエラー一覧
-     * @return API エラーレスポンス
-     */
-    private ResponseEntity<ApiErrorResponse> buildErrorResponse(
-        final HttpStatusCode statusCode,
-        final String message,
-        final HttpServletRequest request,
-        final List<ApiValidationError> validationErrors) {
-
-        return ResponseEntity.status(statusCode)
-            .body(createErrorResponse(
-                statusCode,
-                message,
-                request,
-                validationErrors
-            ));
-    }
-
-    /**
-     * エラーレスポンス本体を生成する
-     *
-     * @param statusCode       HTTP ステータス
-     * @param message          エラーメッセージ
-     * @param request          HTTP リクエスト
-     * @param validationErrors バリデーションエラー一覧
-     * @return エラーレスポンス本体
-     */
-    private ApiErrorResponse createErrorResponse(
-        final HttpStatusCode statusCode,
-        final String message,
-        final HttpServletRequest request,
-        final List<ApiValidationError> validationErrors) {
-
-        return new ApiErrorResponse(
-            OffsetDateTime.now(),
-            statusCode.value(),
-            resolveErrorCode(statusCode),
-            message,
-            request.getRequestURI(),
-            validationErrors
-        );
-    }
-
-    /**
-     * HTTP ステータスコードを API レスポンス用のエラーコード文字列へ変換する
-     *
-     * @param statusCode HTTP ステータス
-     * @return エラーコード文字列
-     */
-    private String resolveErrorCode(final HttpStatusCode statusCode) {
-        return Optional.ofNullable(HttpStatus.resolve(statusCode.value()))
-            .map(HttpStatus::name)
-            .orElse("HTTP_" + statusCode.value());
-    }
+  /**
+   * HTTP ステータスコードを API レスポンス用のエラーコード文字列へ変換する
+   *
+   * @param statusCode HTTP ステータス
+   * @return エラーコード文字列
+   */
+  private String resolveErrorCode(final HttpStatusCode statusCode) {
+    return Optional.ofNullable(HttpStatus.resolve(statusCode.value()))
+        .map(HttpStatus::name)
+        .orElse("HTTP_" + statusCode.value());
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiValidationError.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiValidationError.java
@@ -3,11 +3,7 @@ package jp.co.shimizutdev.phoneorderapi.presentation.error;
 /**
  * APIバリデーションエラー
  *
- * @param field   エラー対象項目
+ * @param field エラー対象項目
  * @param message エラーメッセージ
  */
-public record ApiValidationError(
-    String field,
-    String message
-) {
-}
+public record ApiValidationError(String field, String message) {}

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilter.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilter.java
@@ -4,6 +4,14 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.stream.Collectors;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.log.LogMasker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,327 +22,308 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.charset.IllegalCharsetNameException;
-import java.nio.charset.StandardCharsets;
-import java.nio.charset.UnsupportedCharsetException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.stream.Collectors;
-
-/**
- * リクエスト/レスポンスのログを出力するフィルタ
- */
+/** リクエスト/レスポンスのログを出力するフィルタ */
 @Component
 @Order(2)
 @Slf4j
 @RequiredArgsConstructor
 public class RequestResponseLogFilter extends OncePerRequestFilter {
 
-    /**
-     * 本文ログ最大文字数
-     */
-    private static final int MAX_LOG_BODY_LENGTH = 5000;
+  /** 本文ログ最大文字数 */
+  private static final int MAX_LOG_BODY_LENGTH = 5000;
 
-    /**
-     * リクエスト本文キャッシュ上限バイト数
-     */
-    private static final int REQUEST_CONTENT_CACHE_LIMIT = 8192;
+  /** リクエスト本文キャッシュ上限バイト数 */
+  private static final int REQUEST_CONTENT_CACHE_LIMIT = 8192;
 
-    /**
-     * ログマスキング
-     */
-    private final LogMasker logMasker;
+  /** ログマスキング */
+  private final LogMasker logMasker;
 
-    /**
-     * リクエスト / レスポンスのログを出力する
-     *
-     * @param request     HTTPリクエスト
-     * @param response    HTTPレスポンス
-     * @param filterChain フィルタチェーン
-     * @throws ServletException ServletException
-     * @throws IOException      IOException
-     */
-    @Override
-    protected void doFilterInternal(
-        @NonNull final HttpServletRequest request,
-        @NonNull final HttpServletResponse response,
-        @NonNull final FilterChain filterChain) throws ServletException, IOException {
+  /**
+   * リクエスト / レスポンスのログを出力する
+   *
+   * @param request HTTPリクエスト
+   * @param response HTTPレスポンス
+   * @param filterChain フィルタチェーン
+   * @throws ServletException ServletException
+   * @throws IOException IOException
+   */
+  @Override
+  protected void doFilterInternal(
+      @NonNull final HttpServletRequest request,
+      @NonNull final HttpServletResponse response,
+      @NonNull final FilterChain filterChain)
+      throws ServletException, IOException {
 
-        ContentCachingRequestWrapper wrappedRequest = wrapRequest(request);
-        ContentCachingResponseWrapper wrappedResponse = wrapResponse(response);
+    ContentCachingRequestWrapper wrappedRequest = wrapRequest(request);
+    ContentCachingResponseWrapper wrappedResponse = wrapResponse(response);
 
-        long startTimeMillis = System.currentTimeMillis();
-        Exception exception = null;
+    long startTimeMillis = System.currentTimeMillis();
+    Exception exception = null;
 
-        logRequest(wrappedRequest);
+    logRequest(wrappedRequest);
 
-        try {
-            filterChain.doFilter(wrappedRequest, wrappedResponse);
-        } catch (IOException | ServletException | RuntimeException ex) {
-            exception = ex;
-            throw ex;
-        } finally {
-            long durationMillis = System.currentTimeMillis() - startTimeMillis;
-            logAfterCompletion(wrappedRequest, wrappedResponse, durationMillis, exception);
-            wrappedResponse.copyBodyToResponse();
-        }
+    try {
+      filterChain.doFilter(wrappedRequest, wrappedResponse);
+    } catch (IOException | ServletException | RuntimeException ex) {
+      exception = ex;
+      throw ex;
+    } finally {
+      long durationMillis = System.currentTimeMillis() - startTimeMillis;
+      logAfterCompletion(wrappedRequest, wrappedResponse, durationMillis, exception);
+      wrappedResponse.copyBodyToResponse();
+    }
+  }
+
+  /**
+   * リクエストをラップする
+   *
+   * @param request HTTPリクエスト
+   * @return ラップ済みリクエスト
+   */
+  private ContentCachingRequestWrapper wrapRequest(final HttpServletRequest request) {
+    if (request instanceof ContentCachingRequestWrapper wrapper) {
+      return wrapper;
+    }
+    return new ContentCachingRequestWrapper(request, REQUEST_CONTENT_CACHE_LIMIT);
+  }
+
+  /**
+   * レスポンスをラップする
+   *
+   * @param response HTTPレスポンス
+   * @return ラップ済みレスポンス
+   */
+  private ContentCachingResponseWrapper wrapResponse(final HttpServletResponse response) {
+    if (response instanceof ContentCachingResponseWrapper wrapper) {
+      return wrapper;
+    }
+    return new ContentCachingResponseWrapper(response);
+  }
+
+  /**
+   * リクエストログを出力する
+   *
+   * @param request HTTPリクエスト
+   */
+  private void logRequest(final ContentCachingRequestWrapper request) {
+    log.info("[request] http method: {}", request.getMethod());
+    log.info("[request] request uri: {}", request.getRequestURI());
+    log.info("[request] content-type: {}", nullToEmpty(request.getContentType()));
+    log.info("[request] client ip: {}", getClientIpAddress(request));
+    log.info("[request] request id: {}", getRequestId(request));
+
+    if (log.isDebugEnabled()) {
+      log.debug("[request] query string: {}", nullToEmpty(request.getQueryString()));
+      log.debug("[request] parameters: {}", getParameters(request));
+      log.debug("[request] headers: {}", getHeaders(request));
+    }
+  }
+
+  /**
+   * パラメータを取得する
+   *
+   * @param request HTTPリクエスト
+   * @return パラメータ文字列。存在しない場合は空文字
+   */
+  private String getParameters(final ContentCachingRequestWrapper request) {
+    return request.getParameterMap().entrySet().stream()
+        .map(entry -> entry.getKey() + "=" + Arrays.toString(entry.getValue()))
+        .collect(Collectors.joining(","));
+  }
+
+  /**
+   * リクエストヘッダーを取得する
+   *
+   * @param request HTTPリクエスト
+   * @return リクエストヘッダー文字列。存在しない場合は空文字
+   */
+  private String getHeaders(final ContentCachingRequestWrapper request) {
+    return Collections.list(request.getHeaderNames()).stream()
+        .map(
+            headerName ->
+                headerName + "=" + logMasker.maskHeader(headerName, request.getHeader(headerName)))
+        .collect(Collectors.joining(","));
+  }
+
+  /**
+   * レスポンスヘッダーを取得する
+   *
+   * @param response HTTPレスポンス
+   * @return レスポンスヘッダー文字列。存在しない場合は空文字
+   */
+  private String getHeaders(final ContentCachingResponseWrapper response) {
+    return response.getHeaderNames().stream()
+        .map(
+            headerName ->
+                headerName + "=" + logMasker.maskHeader(headerName, response.getHeader(headerName)))
+        .collect(Collectors.joining(","));
+  }
+
+  /**
+   * リクエスト / レスポンスの完了後ログを出力する
+   *
+   * @param request HTTPリクエスト
+   * @param response HTTPレスポンス
+   * @param durationMillis 処理時間
+   * @param exception 例外
+   */
+  private void logAfterCompletion(
+      final ContentCachingRequestWrapper request,
+      final ContentCachingResponseWrapper response,
+      final long durationMillis,
+      final Exception exception) {
+
+    log.info("[response] status: {}", response.getStatus());
+    log.info("[response] content-type: {}", nullToEmpty(response.getContentType()));
+    log.info("[response] duration(ms): {}", durationMillis);
+
+    if (log.isDebugEnabled()) {
+      log.debug("[request] body: {}", getRequestBody(request));
+      log.debug("[response] headers: {}", getHeaders(response));
+      log.debug("[response] body: {}", getResponseBody(response));
+      log.debug("[response] size(bytes): {}", response.getContentAsByteArray().length);
     }
 
-    /**
-     * リクエストをラップする
-     *
-     * @param request HTTPリクエスト
-     * @return ラップ済みリクエスト
-     */
-    private ContentCachingRequestWrapper wrapRequest(final HttpServletRequest request) {
-        if (request instanceof ContentCachingRequestWrapper wrapper) {
-            return wrapper;
-        }
-        return new ContentCachingRequestWrapper(request, REQUEST_CONTENT_CACHE_LIMIT);
+    if (exception != null) {
+      log.warn("[exception] class: {}", exception.getClass().getName());
+      log.warn("[exception] message: {}", nullToEmpty(exception.getMessage()));
+    }
+  }
+
+  /**
+   * リクエスト本文を取得する
+   *
+   * @param request HTTPリクエスト
+   * @return リクエスト本文
+   */
+  private String getRequestBody(final ContentCachingRequestWrapper request) {
+    return getBody(
+        request.getContentType(), request.getCharacterEncoding(), request.getContentAsByteArray());
+  }
+
+  /**
+   * レスポンス本文を取得する
+   *
+   * @param response HTTPレスポンス
+   * @return レスポンス本文
+   */
+  private String getResponseBody(final ContentCachingResponseWrapper response) {
+    return getBody(
+        response.getContentType(),
+        response.getCharacterEncoding(),
+        response.getContentAsByteArray());
+  }
+
+  /**
+   * 本文を取得する
+   *
+   * @param contentType Content-Type
+   * @param encoding 文字コード名
+   * @param content 本文バイト配列
+   * @return 本文
+   */
+  private String getBody(final String contentType, final String encoding, final byte[] content) {
+
+    if (!isLoggableContentType(contentType)) {
+      return "[unsupported content type]";
     }
 
-    /**
-     * レスポンスをラップする
-     *
-     * @param response HTTPレスポンス
-     * @return ラップ済みレスポンス
-     */
-    private ContentCachingResponseWrapper wrapResponse(final HttpServletResponse response) {
-        if (response instanceof ContentCachingResponseWrapper wrapper) {
-            return wrapper;
-        }
-        return new ContentCachingResponseWrapper(response);
+    if (content.length == 0) {
+      return "";
     }
 
-    /**
-     * リクエストログを出力する
-     *
-     * @param request HTTPリクエスト
-     */
-    private void logRequest(final ContentCachingRequestWrapper request) {
-        log.info("[request] http method: {}", request.getMethod());
-        log.info("[request] request uri: {}", request.getRequestURI());
-        log.info("[request] content-type: {}", nullToEmpty(request.getContentType()));
-        log.info("[request] client ip: {}", getClientIpAddress(request));
-        log.info("[request] request id: {}", getRequestId(request));
+    return abbreviate(logMasker.maskText(new String(content, getCharset(encoding))));
+  }
 
-        if (log.isDebugEnabled()) {
-            log.debug("[request] query string: {}", nullToEmpty(request.getQueryString()));
-            log.debug("[request] parameters: {}", getParameters(request));
-            log.debug("[request] headers: {}", getHeaders(request));
-        }
+  /**
+   * Content-Type がログ出力対象か判定する
+   *
+   * @param contentType Content-Type
+   * @return Content-Type がログ出力対象の場合 true
+   */
+  private boolean isLoggableContentType(final String contentType) {
+    if (contentType == null || contentType.isBlank()) {
+      return false;
     }
 
-    /**
-     * パラメータを取得する
-     *
-     * @param request HTTPリクエスト
-     * @return パラメータ文字列。存在しない場合は空文字
-     */
-    private String getParameters(final ContentCachingRequestWrapper request) {
-        return request.getParameterMap().entrySet().stream()
-            .map(entry -> entry.getKey() + "=" + Arrays.toString(entry.getValue()))
-            .collect(Collectors.joining(","));
+    return contentType.startsWith("application/json")
+        || contentType.startsWith("application/xml")
+        || contentType.startsWith("application/x-www-form-urlencoded")
+        || contentType.startsWith("text/plain")
+        || contentType.startsWith("text/html");
+  }
+
+  /**
+   * リクエストIDを取得する
+   *
+   * @param request HTTPリクエスト
+   * @return リクエストID
+   */
+  private String getRequestId(final HttpServletRequest request) {
+    String requestId = request.getHeader("X-Request-Id");
+    if (requestId == null || requestId.isBlank()) {
+      requestId = request.getHeader("X-Correlation-Id");
+    }
+    return nullToEmpty(requestId);
+  }
+
+  /**
+   * クライアントIPアドレスを取得する
+   *
+   * @param request HTTPリクエスト
+   * @return クライアントIPアドレス
+   */
+  private String getClientIpAddress(final HttpServletRequest request) {
+    String forwardedFor = request.getHeader("X-Forwarded-For");
+    if (forwardedFor != null && !forwardedFor.isBlank()) {
+      return forwardedFor.split(",")[0].trim();
+    }
+    return request.getRemoteAddr();
+  }
+
+  /**
+   * 文字コードを取得する
+   *
+   * @param encoding 文字コード名
+   * @return 文字コード
+   */
+  private Charset getCharset(final String encoding) {
+    if (encoding == null || encoding.isBlank()) {
+      return StandardCharsets.UTF_8;
     }
 
-    /**
-     * リクエストヘッダーを取得する
-     *
-     * @param request HTTPリクエスト
-     * @return リクエストヘッダー文字列。存在しない場合は空文字
-     */
-    private String getHeaders(final ContentCachingRequestWrapper request) {
-        return Collections.list(request.getHeaderNames()).stream()
-            .map(headerName -> headerName + "=" + logMasker.maskHeader(headerName, request.getHeader(headerName)))
-            .collect(Collectors.joining(","));
+    try {
+      return Charset.forName(encoding);
+    } catch (IllegalCharsetNameException | UnsupportedCharsetException ex) {
+      return StandardCharsets.UTF_8;
+    }
+  }
+
+  /**
+   * 本文を最大文字数に省略する
+   *
+   * @param body 本文
+   * @return 省略後本文
+   */
+  private String abbreviate(final String body) {
+    if (body == null) {
+      return "";
     }
 
-    /**
-     * レスポンスヘッダーを取得する
-     *
-     * @param response HTTPレスポンス
-     * @return レスポンスヘッダー文字列。存在しない場合は空文字
-     */
-    private String getHeaders(final ContentCachingResponseWrapper response) {
-        return response.getHeaderNames().stream()
-            .map(headerName -> headerName + "=" + logMasker.maskHeader(headerName, response.getHeader(headerName)))
-            .collect(Collectors.joining(","));
+    if (body.length() <= MAX_LOG_BODY_LENGTH) {
+      return body;
     }
 
-    /**
-     * リクエスト / レスポンスの完了後ログを出力する
-     *
-     * @param request        HTTPリクエスト
-     * @param response       HTTPレスポンス
-     * @param durationMillis 処理時間
-     * @param exception      例外
-     */
-    private void logAfterCompletion(
-        final ContentCachingRequestWrapper request,
-        final ContentCachingResponseWrapper response,
-        final long durationMillis,
-        final Exception exception) {
+    return body.substring(0, MAX_LOG_BODY_LENGTH) + "...(truncated)";
+  }
 
-        log.info("[response] status: {}", response.getStatus());
-        log.info("[response] content-type: {}", nullToEmpty(response.getContentType()));
-        log.info("[response] duration(ms): {}", durationMillis);
-
-        if (log.isDebugEnabled()) {
-            log.debug("[request] body: {}", getRequestBody(request));
-            log.debug("[response] headers: {}", getHeaders(response));
-            log.debug("[response] body: {}", getResponseBody(response));
-            log.debug("[response] size(bytes): {}", response.getContentAsByteArray().length);
-        }
-
-        if (exception != null) {
-            log.warn("[exception] class: {}", exception.getClass().getName());
-            log.warn("[exception] message: {}", nullToEmpty(exception.getMessage()));
-        }
-    }
-
-    /**
-     * リクエスト本文を取得する
-     *
-     * @param request HTTPリクエスト
-     * @return リクエスト本文
-     */
-    private String getRequestBody(final ContentCachingRequestWrapper request) {
-        return getBody(
-            request.getContentType(),
-            request.getCharacterEncoding(),
-            request.getContentAsByteArray()
-        );
-    }
-
-    /**
-     * レスポンス本文を取得する
-     *
-     * @param response HTTPレスポンス
-     * @return レスポンス本文
-     */
-    private String getResponseBody(final ContentCachingResponseWrapper response) {
-        return getBody(
-            response.getContentType(),
-            response.getCharacterEncoding(),
-            response.getContentAsByteArray()
-        );
-    }
-
-    /**
-     * 本文を取得する
-     *
-     * @param contentType Content-Type
-     * @param encoding    文字コード名
-     * @param content     本文バイト配列
-     * @return 本文
-     */
-    private String getBody(
-        final String contentType,
-        final String encoding,
-        final byte[] content) {
-
-        if (!isLoggableContentType(contentType)) {
-            return "[unsupported content type]";
-        }
-
-        if (content.length == 0) {
-            return "";
-        }
-
-        return abbreviate(logMasker.maskText(new String(content, getCharset(encoding))));
-    }
-
-    /**
-     * Content-Type がログ出力対象か判定する
-     *
-     * @param contentType Content-Type
-     * @return Content-Type がログ出力対象の場合 true
-     */
-    private boolean isLoggableContentType(final String contentType) {
-        if (contentType == null || contentType.isBlank()) {
-            return false;
-        }
-
-        return contentType.startsWith("application/json")
-            || contentType.startsWith("application/xml")
-            || contentType.startsWith("application/x-www-form-urlencoded")
-            || contentType.startsWith("text/plain")
-            || contentType.startsWith("text/html");
-    }
-
-    /**
-     * リクエストIDを取得する
-     *
-     * @param request HTTPリクエスト
-     * @return リクエストID
-     */
-    private String getRequestId(final HttpServletRequest request) {
-        String requestId = request.getHeader("X-Request-Id");
-        if (requestId == null || requestId.isBlank()) {
-            requestId = request.getHeader("X-Correlation-Id");
-        }
-        return nullToEmpty(requestId);
-    }
-
-    /**
-     * クライアントIPアドレスを取得する
-     *
-     * @param request HTTPリクエスト
-     * @return クライアントIPアドレス
-     */
-    private String getClientIpAddress(final HttpServletRequest request) {
-        String forwardedFor = request.getHeader("X-Forwarded-For");
-        if (forwardedFor != null && !forwardedFor.isBlank()) {
-            return forwardedFor.split(",")[0].trim();
-        }
-        return request.getRemoteAddr();
-    }
-
-    /**
-     * 文字コードを取得する
-     *
-     * @param encoding 文字コード名
-     * @return 文字コード
-     */
-    private Charset getCharset(final String encoding) {
-        if (encoding == null || encoding.isBlank()) {
-            return StandardCharsets.UTF_8;
-        }
-
-        try {
-            return Charset.forName(encoding);
-        } catch (IllegalCharsetNameException | UnsupportedCharsetException ex) {
-            return StandardCharsets.UTF_8;
-        }
-    }
-
-    /**
-     * 本文を最大文字数に省略する
-     *
-     * @param body 本文
-     * @return 省略後本文
-     */
-    private String abbreviate(final String body) {
-        if (body == null) {
-            return "";
-        }
-
-        if (body.length() <= MAX_LOG_BODY_LENGTH) {
-            return body;
-        }
-
-        return body.substring(0, MAX_LOG_BODY_LENGTH) + "...(truncated)";
-    }
-
-    /**
-     * null を空文字へ変換する
-     *
-     * @param value 変換対象文字列
-     * @return null の場合は空文字、それ以外の場合は変換対象文字列
-     */
-    private String nullToEmpty(final String value) {
-        return value == null ? "" : value;
-    }
+  /**
+   * null を空文字へ変換する
+   *
+   * @param value 変換対象文字列
+   * @return null の場合は空文字、それ以外の場合は変換対象文字列
+   */
+  private String nullToEmpty(final String value) {
+    return value == null ? "" : value;
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilter.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilter.java
@@ -4,6 +4,9 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 import org.springframework.core.annotation.Order;
@@ -11,110 +14,93 @@ import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import java.io.IOException;
-import java.util.UUID;
-import java.util.regex.Pattern;
-
-/**
- * トレースIDをMDCへ設定するFilter
- */
+/** トレースIDをMDCへ設定するFilter */
 @Component
 @Order(1)
 @Slf4j
 public class TraceIdFilter extends OncePerRequestFilter {
 
-    /**
-     * トレースIDキー
-     */
-    public static final String TRACE_ID_KEY = "traceId";
+  /** トレースIDキー */
+  public static final String TRACE_ID_KEY = "traceId";
 
-    /**
-     * リクエストから traceId を引き継ぐためのヘッダー名
-     */
-    private static final String REQUEST_ID_HEADER = "X-Request-Id";
+  /** リクエストから traceId を引き継ぐためのヘッダー名 */
+  private static final String REQUEST_ID_HEADER = "X-Request-Id";
 
-    /**
-     * リクエストから correlationId を引き継ぐためのヘッダー名
-     */
-    private static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
+  /** リクエストから correlationId を引き継ぐためのヘッダー名 */
+  private static final String CORRELATION_ID_HEADER = "X-Correlation-Id";
 
-    /**
-     * レスポンスへ traceId を返却するためのヘッダー名
-     */
-    private static final String TRACE_ID_HEADER = "X-Trace-Id";
+  /** レスポンスへ traceId を返却するためのヘッダー名 */
+  private static final String TRACE_ID_HEADER = "X-Trace-Id";
 
-    /**
-     * 受け入れる traceId の最大文字数
-     */
-    private static final int TRACE_ID_MAX_LENGTH = 128;
+  /** 受け入れる traceId の最大文字数 */
+  private static final int TRACE_ID_MAX_LENGTH = 128;
 
-    /**
-     * 受け入れる traceId の文字種パターン
-     */
-    private static final Pattern TRACE_ID_PATTERN = Pattern.compile("^[A-Za-z0-9._-]+$");
+  /** 受け入れる traceId の文字種パターン */
+  private static final Pattern TRACE_ID_PATTERN = Pattern.compile("^[A-Za-z0-9._-]+$");
 
-    /**
-     * トレースIDを設定してフィルタチェーンを実行する
-     *
-     * @param request     HTTPリクエスト
-     * @param response    HTTPレスポンス
-     * @param filterChain フィルタチェーン
-     * @throws ServletException ServletException
-     * @throws IOException      IOException
-     */
-    @Override
-    protected void doFilterInternal(
-        @NonNull final HttpServletRequest request,
-        @NonNull final HttpServletResponse response,
-        @NonNull final FilterChain filterChain) throws ServletException, IOException {
+  /**
+   * トレースIDを設定してフィルタチェーンを実行する
+   *
+   * @param request HTTPリクエスト
+   * @param response HTTPレスポンス
+   * @param filterChain フィルタチェーン
+   * @throws ServletException ServletException
+   * @throws IOException IOException
+   */
+  @Override
+  protected void doFilterInternal(
+      @NonNull final HttpServletRequest request,
+      @NonNull final HttpServletResponse response,
+      @NonNull final FilterChain filterChain)
+      throws ServletException, IOException {
 
-        String traceId = resolveTraceId(request);
+    String traceId = resolveTraceId(request);
 
-        try {
-            MDC.put(TRACE_ID_KEY, traceId);
-            response.setHeader(TRACE_ID_HEADER, traceId);
-            filterChain.doFilter(request, response);
-        } finally {
-            MDC.remove(TRACE_ID_KEY);
-        }
+    try {
+      MDC.put(TRACE_ID_KEY, traceId);
+      response.setHeader(TRACE_ID_HEADER, traceId);
+      filterChain.doFilter(request, response);
+    } finally {
+      MDC.remove(TRACE_ID_KEY);
+    }
+  }
+
+  /**
+   * リクエストから traceId を解決する
+   *
+   * @param request HTTP リクエスト
+   * @return traceId
+   */
+  private String resolveTraceId(final HttpServletRequest request) {
+    String requestId = request.getHeader(REQUEST_ID_HEADER);
+
+    if (isValidTraceId(requestId)) {
+      return requestId.trim();
     }
 
-    /**
-     * リクエストから traceId を解決する
-     *
-     * @param request HTTP リクエスト
-     * @return traceId
-     */
-    private String resolveTraceId(final HttpServletRequest request) {
-        String requestId = request.getHeader(REQUEST_ID_HEADER);
-
-        if (isValidTraceId(requestId)) {
-            return requestId.trim();
-        }
-
-        String correlationId = request.getHeader(CORRELATION_ID_HEADER);
-        if (isValidTraceId(correlationId)) {
-            return correlationId.trim();
-        }
-
-        return UUID.randomUUID().toString();
+    String correlationId = request.getHeader(CORRELATION_ID_HEADER);
+    if (isValidTraceId(correlationId)) {
+      return correlationId.trim();
     }
 
-    /**
-     * 指定された traceId が受け入れ可能かを検証する
-     *
-     * @param traceId 検証対象の traceId
-     * @return traceId が空でなく、長さ制限内で、許可パターンに一致する場合は {@code true}
-     */
-    private boolean isValidTraceId(final String traceId) {
-        if (traceId == null) {
-            return false;
-        }
+    return UUID.randomUUID().toString();
+  }
 
-        String normalizedTraceId = traceId.trim();
-
-        return !normalizedTraceId.isEmpty()
-            && normalizedTraceId.length() <= TRACE_ID_MAX_LENGTH
-            && TRACE_ID_PATTERN.matcher(normalizedTraceId).matches();
+  /**
+   * 指定された traceId が受け入れ可能かを検証する
+   *
+   * @param traceId 検証対象の traceId
+   * @return traceId が空でなく、長さ制限内で、許可パターンに一致する場合は {@code true}
+   */
+  private boolean isValidTraceId(final String traceId) {
+    if (traceId == null) {
+      return false;
     }
+
+    String normalizedTraceId = traceId.trim();
+
+    return !normalizedTraceId.isEmpty()
+        && normalizedTraceId.length() <= TRACE_ID_MAX_LENGTH
+        && TRACE_ID_PATTERN.matcher(normalizedTraceId).matches();
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderController.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderController.java
@@ -12,77 +12,71 @@ import jp.co.shimizutdev.phoneorderapi.presentation.generated.model.OrderRespons
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 注文コントローラ
- */
+/** 注文コントローラ */
 @RestController
 @RequiredArgsConstructor
 public class OrderController implements OrdersApi {
 
-    /**
-     * 注文サービス
-     */
-    private final OrderService orderService;
+  /** 注文サービス */
+  private final OrderService orderService;
 
-    /**
-     * 注文一覧を取得する
-     *
-     * @param page 取得ページ番号。0 始まり。null の場合はデフォルトページ番号
-     * @param size 1 ページあたりの取得件数。null の場合はデフォルトページサイズ
-     * @return 注文日時降順、同一日時は注文コード降順のページング済み注文レスポンス。範囲外ページの場合は空のページ
-     */
-    @Override
-    public OrderPageResponse getOrders(final Integer page, final Integer size) {
-        PageResult<Order> orders = orderService.getOrders(PagingCondition.ofNullable(page, size));
-        return OrderMapper.toPageResponse(orders);
-    }
+  /**
+   * 注文一覧を取得する
+   *
+   * @param page 取得ページ番号。0 始まり。null の場合はデフォルトページ番号
+   * @param size 1 ページあたりの取得件数。null の場合はデフォルトページサイズ
+   * @return 注文日時降順、同一日時は注文コード降順のページング済み注文レスポンス。範囲外ページの場合は空のページ
+   */
+  @Override
+  public OrderPageResponse getOrders(final Integer page, final Integer size) {
+    PageResult<Order> orders = orderService.getOrders(PagingCondition.ofNullable(page, size));
+    return OrderMapper.toPageResponse(orders);
+  }
 
-    /**
-     * 注文コードで注文を取得する
-     *
-     * @param orderCode 注文コード
-     * @return 注文レスポンス
-     * @throws IllegalArgumentException 注文コードの形式が不正な場合
-     * @throws OrderNotFoundException 注文コードに対応する注文が存在しない場合
-     */
-    @Override
-    public OrderResponse getOrderByOrderCode(final String orderCode) {
-        Order order = orderService.getOrderByOrderCode(OrderCode.of(orderCode));
-        return OrderMapper.toResponse(order);
-    }
+  /**
+   * 注文コードで注文を取得する
+   *
+   * @param orderCode 注文コード
+   * @return 注文レスポンス
+   * @throws IllegalArgumentException 注文コードの形式が不正な場合
+   * @throws OrderNotFoundException 注文コードに対応する注文が存在しない場合
+   */
+  @Override
+  public OrderResponse getOrderByOrderCode(final String orderCode) {
+    Order order = orderService.getOrderByOrderCode(OrderCode.of(orderCode));
+    return OrderMapper.toResponse(order);
+  }
 
-    /**
-     * 注文を登録する
-     *
-     * @param createOrderRequest 注文登録リクエスト
-     * @return 注文レスポンス
-     * @throws IllegalArgumentException 注文日時が指定されていない場合
-     */
-    @Override
-    public OrderResponse createOrder(final OrderRequest createOrderRequest) {
-        Order order = orderService.createOrder(OrderedAt.of(createOrderRequest.getOrderedAt()));
-        return OrderMapper.toResponse(order);
-    }
+  /**
+   * 注文を登録する
+   *
+   * @param createOrderRequest 注文登録リクエスト
+   * @return 注文レスポンス
+   * @throws IllegalArgumentException 注文日時が指定されていない場合
+   */
+  @Override
+  public OrderResponse createOrder(final OrderRequest createOrderRequest) {
+    Order order = orderService.createOrder(OrderedAt.of(createOrderRequest.getOrderedAt()));
+    return OrderMapper.toResponse(order);
+  }
 
-    /**
-     * 注文をキャンセルする
-     *
-     * @param orderCode          注文コード
-     * @param cancelOrderRequest 注文キャンセルリクエスト
-     * @return 注文レスポンス
-     * @throws IllegalArgumentException 注文コードまたはバージョンが不正な場合
-     * @throws OrderNotFoundException 注文コードに対応する注文が存在しない場合
-     * @throws OrderCannotBeCancelledException 注文の状態によりキャンセルできない場合
-     * @throws OrderVersionConflictException 注文のバージョンが一致しない場合
-     */
-    @Override
-    public OrderResponse cancelOrder(
-        final String orderCode,
-        final CancelOrderRequest cancelOrderRequest) {
-        Order order = orderService.cancelOrder(
-            OrderCode.of(orderCode),
-            Version.of(cancelOrderRequest.getVersion())
-        );
-        return OrderMapper.toResponse(order);
-    }
+  /**
+   * 注文をキャンセルする
+   *
+   * @param orderCode 注文コード
+   * @param cancelOrderRequest 注文キャンセルリクエスト
+   * @return 注文レスポンス
+   * @throws IllegalArgumentException 注文コードまたはバージョンが不正な場合
+   * @throws OrderNotFoundException 注文コードに対応する注文が存在しない場合
+   * @throws OrderCannotBeCancelledException 注文の状態によりキャンセルできない場合
+   * @throws OrderVersionConflictException 注文のバージョンが一致しない場合
+   */
+  @Override
+  public OrderResponse cancelOrder(
+      final String orderCode, final CancelOrderRequest cancelOrderRequest) {
+    Order order =
+        orderService.cancelOrder(
+            OrderCode.of(orderCode), Version.of(cancelOrderRequest.getVersion()));
+    return OrderMapper.toResponse(order);
+  }
 }

--- a/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderMapper.java
+++ b/src/main/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderMapper.java
@@ -1,79 +1,68 @@
 package jp.co.shimizutdev.phoneorderapi.presentation.order;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PageResult;
 import jp.co.shimizutdev.phoneorderapi.domain.order.Order;
 import jp.co.shimizutdev.phoneorderapi.presentation.generated.model.OrderPageResponse;
 import jp.co.shimizutdev.phoneorderapi.presentation.generated.model.OrderResponse;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-
-/**
- * 注文マッパー
- */
+/** 注文マッパー */
 public class OrderMapper {
 
-    /**
-     * コンストラクタ(インスタンス化を防止)
-     */
-    private OrderMapper() {
+  /** コンストラクタ(インスタンス化を防止) */
+  private OrderMapper() {}
+
+  /**
+   * 注文を注文レスポンスへ変換する
+   *
+   * @param order 注文
+   * @return 注文レスポンス。注文が null の場合は null
+   */
+  public static OrderResponse toResponse(final Order order) {
+    if (order == null) {
+      return null;
     }
 
-    /**
-     * 注文を注文レスポンスへ変換する
-     *
-     * @param order 注文
-     * @return 注文レスポンス。注文が null の場合は null
-     */
-    public static OrderResponse toResponse(final Order order) {
-        if (order == null) {
-            return null;
-        }
+    return new OrderResponse(
+        order.getOrderCode().getValue(),
+        order.getOrderedAt().getValue(),
+        OrderResponse.OrderStatusEnum.fromValue(order.getOrderStatus().getCode()),
+        order.getVersion().getValue());
+  }
 
-        return new OrderResponse(
-            order.getOrderCode().getValue(),
-            order.getOrderedAt().getValue(),
-            OrderResponse.OrderStatusEnum.fromValue(order.getOrderStatus().getCode()),
-            order.getVersion().getValue()
-        );
+  /**
+   * 注文一覧を注文レスポンス一覧へ変換する
+   *
+   * @param orders 注文一覧
+   * @return 注文レスポンス一覧。注文一覧が null の場合は空リスト
+   */
+  public static List<OrderResponse> toResponses(final List<Order> orders) {
+    if (orders == null) {
+      return Collections.emptyList();
     }
 
-    /**
-     * 注文一覧を注文レスポンス一覧へ変換する
-     *
-     * @param orders 注文一覧
-     * @return 注文レスポンス一覧。注文一覧が null の場合は空リスト
-     */
-    public static List<OrderResponse> toResponses(final List<Order> orders) {
-        if (orders == null) {
-            return Collections.emptyList();
-        }
+    return orders.stream().map(OrderMapper::toResponse).filter(Objects::nonNull).toList();
+  }
 
-        return orders.stream()
-            .map(OrderMapper::toResponse)
-            .filter(Objects::nonNull)
-            .toList();
-    }
+  /**
+   * ページング済みの注文一覧をページング済みの注文レスポンスへ変換する
+   *
+   * @param orders ページング済みの注文一覧
+   * @return ページング済みの注文レスポンス
+   * @throws NullPointerException ページング済みの注文一覧が null の場合
+   */
+  public static OrderPageResponse toPageResponse(final PageResult<Order> orders) {
+    Objects.requireNonNull(orders, "ページング済み注文一覧は必須です。");
 
-    /**
-     * ページング済みの注文一覧をページング済みの注文レスポンスへ変換する
-     *
-     * @param orders ページング済みの注文一覧
-     * @return ページング済みの注文レスポンス
-     * @throws NullPointerException ページング済みの注文一覧が null の場合
-     */
-    public static OrderPageResponse toPageResponse(final PageResult<Order> orders) {
-        Objects.requireNonNull(orders, "ページング済み注文一覧は必須です。");
-
-        return new OrderPageResponse(
-            toResponses(orders.items()),
-            orders.page(),
-            orders.size(),
-            orders.totalElements(),
-            orders.totalPages(),
-            orders.hasNext(),
-            orders.hasPrevious()
-        );
-    }
+    return new OrderPageResponse(
+        toResponses(orders.items()),
+        orders.page(),
+        orders.size(),
+        orders.totalElements(),
+        orders.totalPages(),
+        orders.hasNext(),
+        orders.hasPrevious());
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/ArchitectureTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/ArchitectureTest.java
@@ -1,0 +1,43 @@
+package jp.co.shimizutdev.phoneorderapi;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+/** アーキテクチャ依存ルールを検証する */
+@AnalyzeClasses(
+    packages = "jp.co.shimizutdev.phoneorderapi",
+    importOptions = ImportOption.DoNotIncludeTests.class)
+class ArchitectureTest {
+
+  /** domain が外側レイヤや Spring / Servlet / JPA に依存しないことを検証する */
+  @ArchTest
+  @SuppressWarnings("unused")
+  static final ArchRule domain_should_not_depend_on_outer_layers_or_frameworks =
+      noClasses()
+          .that()
+          .resideInAPackage("..domain..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAnyPackage(
+              "..application..",
+              "..presentation..",
+              "..infrastructure..",
+              "org.springframework..",
+              "jakarta.servlet..",
+              "jakarta.persistence..");
+
+  /** application が presentation と infrastructure 詳細に依存しないことを検証する */
+  @ArchTest
+  @SuppressWarnings("unused")
+  static final ArchRule application_should_not_depend_on_presentation_or_infrastructure_details =
+      noClasses()
+          .that()
+          .resideInAPackage("..application..")
+          .should()
+          .dependOnClassesThat()
+          .resideInAnyPackage("..presentation..", "..infrastructure..");
+}

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/application/order/OrderServiceTest.java
@@ -1,6 +1,11 @@
 package jp.co.shimizutdev.phoneorderapi.application.order;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import jakarta.persistence.EntityManager;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PageResult;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PagingCondition;
 import jp.co.shimizutdev.phoneorderapi.domain.order.*;
@@ -16,432 +21,437 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.time.OffsetDateTime;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-/**
- * 注文サービステスト
- */
+/** 注文サービステスト */
 @SpringBootTest
 @Transactional
 class OrderServiceTest extends AbstractPostgreSQLTest {
 
-    /**
-     * 注文サービス
-     */
-    @Autowired
-    private OrderService orderService;
+  /** 注文サービス */
+  @Autowired private OrderService orderService;
+
+  /** 注文リポジトリ */
+  @Autowired private OrderJpaRepository orderJpaRepository;
+
+  /** エンティティマネージャ */
+  @Autowired private EntityManager entityManager;
+
+  /** テスト前処理 */
+  @BeforeEach
+  void setUp() {
+    cleanupOrderTables();
+  }
+
+  /** テスト後処理 */
+  @AfterEach
+  void tearDown() {
+    cleanupOrderTables();
+  }
+
+  /**
+   * 注文データをDBへ直接登録する
+   *
+   * @param orderId 注文ID
+   * @param orderCode 注文コード
+   * @param orderedAt 注文日時
+   * @param orderStatus 注文ステータス
+   * @param version バージョン
+   */
+  private void insertOrder(
+      final UUID orderId,
+      final String orderCode,
+      final OffsetDateTime orderedAt,
+      final String orderStatus,
+      final long version) {
+
+    //noinspection SqlResolve,SqlNoDataSourceInspection
+    entityManager
+        .createNativeQuery(
+            """
+insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by)
+values (:id, :orderCode, :orderedAt, :orderStatus, :version, 'system', 'system')
+""")
+        .setParameter("id", orderId)
+        .setParameter("orderCode", orderCode)
+        .setParameter("orderedAt", orderedAt)
+        .setParameter("orderStatus", orderStatus)
+        .setParameter("version", version)
+        .executeUpdate();
+    entityManager.flush();
+    entityManager.clear();
+  }
+
+  /** 注文関連テーブルを初期化する */
+  private void cleanupOrderTables() {
+    entityManager.createNativeQuery("truncate table orders cascade").executeUpdate();
+    entityManager.createNativeQuery("alter sequence order_code_seq restart with 1").executeUpdate();
+    entityManager.flush();
+    entityManager.clear();
+  }
+
+  @Nested
+  @DisplayName("getOrderByOrderCode")
+  class GetOrderByOrderCode {
 
     /**
-     * 注文リポジトリ
-     */
-    @Autowired
-    private OrderJpaRepository orderJpaRepository;
-
-    /**
-     * エンティティマネージャ
-     */
-    @Autowired
-    private EntityManager entityManager;
-
-    /**
-     * テスト前処理
-     */
-    @BeforeEach
-    void setUp() {
-        cleanupOrderTables();
-    }
-
-    /**
-     * テスト後処理
-     */
-    @AfterEach
-    void tearDown() {
-        cleanupOrderTables();
-    }
-
-    /**
-     * 注文データをDBへ直接登録する
      *
-     * @param orderId     注文ID
-     * @param orderCode   注文コード
-     * @param orderedAt   注文日時
-     * @param orderStatus 注文ステータス
-     * @param version     バージョン
+     *
+     * <pre>
+     * Given 注文データが保存されている
+     * When 注文コードで注文を取得する
+     * Then 対象注文が取得できる
+     * </pre>
      */
-    private void insertOrder(
-        final UUID orderId,
-        final String orderCode,
-        final OffsetDateTime orderedAt,
-        final String orderStatus,
-        final long version) {
+    @Test
+    @DisplayName("注文コードで注文を取得できること")
+    void shouldGetOrderByOrderCode() {
+      insertOrder(
+          UUID.fromString("00000000-0000-0000-0000-000000000001"),
+          "ORD000001",
+          OffsetDateTime.parse("2026-04-09T10:15:30+09:00"),
+          "001",
+          2L);
 
-        //noinspection SqlResolve,SqlNoDataSourceInspection
-        entityManager.createNativeQuery("""
-                insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by)
-                values (:id, :orderCode, :orderedAt, :orderStatus, :version, 'system', 'system')
-                """)
-            .setParameter("id", orderId)
-            .setParameter("orderCode", orderCode)
-            .setParameter("orderedAt", orderedAt)
-            .setParameter("orderStatus", orderStatus)
-            .setParameter("version", version)
-            .executeUpdate();
-        entityManager.flush();
-        entityManager.clear();
+      Order actual = orderService.getOrderByOrderCode(OrderCode.of("ORD000001"));
+
+      assertEquals(
+          "00000000-0000-0000-0000-000000000001", actual.getOrderId().getValue().toString());
+      assertEquals("ORD000001", actual.getOrderCode().getValue());
+      assertEquals("2026-04-09T01:15:30Z", actual.getOrderedAt().getValue().toInstant().toString());
+      assertEquals("001", actual.getOrderStatus().getCode());
+      assertEquals(2L, actual.getVersion().getValue());
     }
 
     /**
-     * 注文関連テーブルを初期化する
+     *
+     *
+     * <pre>
+     * Given 対象注文が登録されていない
+     * When 注文コードで注文を取得する
+     * Then 注文未存在例外が発生する
+     * </pre>
      */
-    private void cleanupOrderTables() {
-        entityManager.createNativeQuery("truncate table orders cascade").executeUpdate();
-        entityManager.createNativeQuery("alter sequence order_code_seq restart with 1").executeUpdate();
-        entityManager.flush();
-        entityManager.clear();
+    @Test
+    @DisplayName("注文コードに対応する注文が存在しない場合に注文未存在例外が発生すること")
+    void shouldThrowExceptionWhenOrderDoesNotExist() {
+      OrderCode orderCode = OrderCode.of("ORD999999");
+
+      OrderNotFoundException actual =
+          assertThrows(
+              OrderNotFoundException.class, () -> orderService.getOrderByOrderCode(orderCode));
+
+      assertEquals("注文が見つかりません: orderCode=ORD999999", actual.getMessage());
+    }
+  }
+
+  @Nested
+  @DisplayName("getOrders")
+  class GetOrders {
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文データが複数件保存されている
+     * When ページング条件を指定して注文一覧を取得する
+     * Then 注文日時降順、同一日時は注文コード降順のページング済み注文一覧とページ情報が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文一覧を取得できること")
+    void shouldGetOrders() {
+      insertOrder(
+          UUID.fromString("00000000-0000-0000-0000-000000000001"),
+          "ORD000001",
+          OffsetDateTime.parse("2026-04-09T10:00:00+09:00"),
+          "001",
+          0L);
+      insertOrder(
+          UUID.fromString("00000000-0000-0000-0000-000000000002"),
+          "ORD000002",
+          OffsetDateTime.parse("2026-04-09T11:00:00+09:00"),
+          "002",
+          1L);
+
+      PageResult<Order> actual = orderService.getOrders(PagingCondition.of(0, 20));
+
+      assertEquals(2, actual.items().size());
+      assertEquals(
+          "00000000-0000-0000-0000-000000000002",
+          actual.items().getFirst().getOrderId().getValue().toString());
+      assertEquals("ORD000002", actual.items().getFirst().getOrderCode().getValue());
+      assertEquals(
+          "2026-04-09T02:00:00Z",
+          actual.items().getFirst().getOrderedAt().getValue().toInstant().toString());
+      assertEquals("002", actual.items().getFirst().getOrderStatus().getCode());
+      assertEquals(1L, actual.items().getFirst().getVersion().getValue());
+      assertEquals(
+          "00000000-0000-0000-0000-000000000001",
+          actual.items().get(1).getOrderId().getValue().toString());
+      assertEquals("ORD000001", actual.items().get(1).getOrderCode().getValue());
+      assertEquals(
+          "2026-04-09T01:00:00Z",
+          actual.items().get(1).getOrderedAt().getValue().toInstant().toString());
+      assertEquals("001", actual.items().get(1).getOrderStatus().getCode());
+      assertEquals(0L, actual.items().get(1).getVersion().getValue());
+      assertEquals(0, actual.page());
+      assertEquals(20, actual.size());
+      assertEquals(2, actual.totalElements());
+      assertEquals(1, actual.totalPages());
+      assertFalse(actual.hasNext());
+      assertFalse(actual.hasPrevious());
     }
 
-    @Nested
-    @DisplayName("getOrderByOrderCode")
-    class GetOrderByOrderCode {
+    /**
+     *
+     *
+     * <pre>
+     * Given ページング条件を用意しない
+     * When 注文一覧を取得する
+     * Then ページング条件必須例外が発生する
+     * </pre>
+     */
+    @Test
+    @DisplayName("ページング条件がnullの場合は例外になること")
+    void shouldThrowExceptionWhenPagingConditionIsNull() {
+      NullPointerException actual =
+          assertThrows(NullPointerException.class, () -> orderService.getOrders(null));
 
-        /**
-         * <pre>
-         * Given 注文データが保存されている
-         * When 注文コードで注文を取得する
-         * Then 対象注文が取得できる
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文コードで注文を取得できること")
-        void shouldGetOrderByOrderCode() {
-            insertOrder(
-                UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                "ORD000001",
-                OffsetDateTime.parse("2026-04-09T10:15:30+09:00"),
-                "001",
-                2L
-            );
+      assertEquals("ページング条件は必須です。", actual.getMessage());
+    }
+  }
 
-            Order actual = orderService.getOrderByOrderCode(OrderCode.of("ORD000001"));
+  @Nested
+  @DisplayName("createOrder")
+  class CreateOrder {
 
-            assertEquals("00000000-0000-0000-0000-000000000001", actual.getOrderId().getValue().toString());
-            assertEquals("ORD000001", actual.getOrderCode().getValue());
-            assertEquals("2026-04-09T01:15:30Z", actual.getOrderedAt().getValue().toInstant().toString());
-            assertEquals("001", actual.getOrderStatus().getCode());
-            assertEquals(2L, actual.getVersion().getValue());
-        }
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文日時を用意する
+     * When 注文を登録する
+     * Then 注文が保存され注文コードと初期ステータスが設定される
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文を登録できること")
+    void shouldCreateOrder() {
+      Order createdOrder =
+          orderService.createOrder(OrderedAt.of(OffsetDateTime.parse("2026-04-09T10:15:30+09:00")));
 
-        /**
-         * <pre>
-         * Given 対象注文が登録されていない
-         * When 注文コードで注文を取得する
-         * Then 注文未存在例外が発生する
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文コードに対応する注文が存在しない場合に注文未存在例外が発生すること")
-        void shouldThrowExceptionWhenOrderDoesNotExist() {
-            OrderCode orderCode = OrderCode.of("ORD999999");
+      assertEquals("ORD000001", createdOrder.getOrderCode().getValue());
+      assertEquals("2026-04-09T10:15:30+09:00", createdOrder.getOrderedAt().getValue().toString());
+      assertEquals("001", createdOrder.getOrderStatus().getCode());
+      assertEquals(0L, createdOrder.getVersion().getValue());
 
-            OrderNotFoundException actual = assertThrows(
-                OrderNotFoundException.class,
-                () -> orderService.getOrderByOrderCode(orderCode)
-            );
-
-            assertEquals("注文が見つかりません: orderCode=ORD999999", actual.getMessage());
-        }
+      Optional<OrderJpaEntity> actual =
+          orderJpaRepository.findByOrderCode(createdOrder.getOrderCode().getValue());
+      assertTrue(actual.isPresent());
+      assertEquals("ORD000001", actual.get().getOrderCode());
+      assertEquals("2026-04-09T10:15:30+09:00", actual.get().getOrderedAt().toString());
+      assertEquals("001", actual.get().getOrderStatus());
+      assertEquals(0L, actual.get().getVersion());
     }
 
-    @Nested
-    @DisplayName("getOrders")
-    class GetOrders {
+    /**
+     *
+     *
+     * <pre>
+     * Given X-User-Id を含むリクエストコンテキストを設定する
+     * When 注文を作成する
+     * Then createdBy と updatedBy にリクエストユーザーが保存される
+     * </pre>
+     */
+    @Test
+    @DisplayName("リクエストヘッダーのユーザー情報が監査項目へ反映されること")
+    void shouldUseRequestUserForAuditWhenCreatingOrder() {
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("X-User-Id", "user-123");
+      RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
-        /**
-         * <pre>
-         * Given 注文データが複数件保存されている
-         * When ページング条件を指定して注文一覧を取得する
-         * Then 注文日時降順、同一日時は注文コード降順のページング済み注文一覧とページ情報が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文一覧を取得できること")
-        void shouldGetOrders() {
-            insertOrder(
-                UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                "ORD000001",
-                OffsetDateTime.parse("2026-04-09T10:00:00+09:00"),
-                "001",
-                0L
-            );
-            insertOrder(
-                UUID.fromString("00000000-0000-0000-0000-000000000002"),
-                "ORD000002",
-                OffsetDateTime.parse("2026-04-09T11:00:00+09:00"),
-                "002",
-                1L
-            );
+      try {
+        Order createdOrder =
+            orderService.createOrder(
+                OrderedAt.of(OffsetDateTime.parse("2026-04-09T10:15:30+09:00")));
 
-            PageResult<Order> actual = orderService.getOrders(PagingCondition.of(0, 20));
+        Optional<OrderJpaEntity> actual =
+            orderJpaRepository.findByOrderCode(createdOrder.getOrderCode().getValue());
+        assertTrue(actual.isPresent());
+        assertEquals("ORD000001", actual.get().getOrderCode());
+        assertEquals("2026-04-09T10:15:30+09:00", actual.get().getOrderedAt().toString());
+        assertEquals("001", actual.get().getOrderStatus());
+        assertEquals(0L, actual.get().getVersion());
+        assertEquals("user-123", actual.get().getCreatedBy());
+        assertEquals("user-123", actual.get().getUpdatedBy());
+      } finally {
+        RequestContextHolder.resetRequestAttributes();
+      }
+    }
+  }
 
-            assertEquals(2, actual.items().size());
-            assertEquals("00000000-0000-0000-0000-000000000002", actual.items().getFirst().getOrderId().getValue().toString());
-            assertEquals("ORD000002", actual.items().getFirst().getOrderCode().getValue());
-            assertEquals("2026-04-09T02:00:00Z", actual.items().getFirst().getOrderedAt().getValue().toInstant().toString());
-            assertEquals("002", actual.items().getFirst().getOrderStatus().getCode());
-            assertEquals(1L, actual.items().getFirst().getVersion().getValue());
-            assertEquals("00000000-0000-0000-0000-000000000001", actual.items().get(1).getOrderId().getValue().toString());
-            assertEquals("ORD000001", actual.items().get(1).getOrderCode().getValue());
-            assertEquals("2026-04-09T01:00:00Z", actual.items().get(1).getOrderedAt().getValue().toInstant().toString());
-            assertEquals("001", actual.items().get(1).getOrderStatus().getCode());
-            assertEquals(0L, actual.items().get(1).getVersion().getValue());
-            assertEquals(0, actual.page());
-            assertEquals(20, actual.size());
-            assertEquals(2, actual.totalElements());
-            assertEquals(1, actual.totalPages());
-            assertFalse(actual.hasNext());
-            assertFalse(actual.hasPrevious());
-        }
+  @Nested
+  @DisplayName("cancelOrder")
+  class CancelOrder {
 
-        /**
-         * <pre>
-         * Given ページング条件を用意しない
-         * When 注文一覧を取得する
-         * Then ページング条件必須例外が発生する
-         * </pre>
-         */
-        @Test
-        @DisplayName("ページング条件がnullの場合は例外になること")
-        void shouldThrowExceptionWhenPagingConditionIsNull() {
-            NullPointerException actual = assertThrows(
-                NullPointerException.class,
-                () -> orderService.getOrders(null)
-            );
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文データが保存されている
+     * When 注文をキャンセルする
+     * Then 注文ステータスがキャンセルで保存される
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文をキャンセルできること")
+    void shouldCancelOrder() {
+      insertOrder(
+          UUID.fromString("00000000-0000-0000-0000-000000000001"),
+          "ORD000001",
+          OffsetDateTime.parse("2026-04-09T10:15:30+09:00"),
+          "001",
+          0L);
 
-            assertEquals("ページング条件は必須です。", actual.getMessage());
-        }
+      Order actual = orderService.cancelOrder(OrderCode.of("ORD000001"), Version.of(0L));
+
+      assertEquals(
+          "00000000-0000-0000-0000-000000000001", actual.getOrderId().getValue().toString());
+      assertEquals("ORD000001", actual.getOrderCode().getValue());
+      assertEquals("2026-04-09T01:15:30Z", actual.getOrderedAt().getValue().toInstant().toString());
+      assertEquals("006", actual.getOrderStatus().getCode());
+      assertEquals(1L, actual.getVersion().getValue());
+
+      Optional<OrderJpaEntity> savedOrder = orderJpaRepository.findByOrderCode("ORD000001");
+      assertTrue(savedOrder.isPresent());
+      assertEquals("00000000-0000-0000-0000-000000000001", savedOrder.get().getId().toString());
+      assertEquals("ORD000001", savedOrder.get().getOrderCode());
+      assertEquals("2026-04-09T01:15:30Z", savedOrder.get().getOrderedAt().toInstant().toString());
+      assertEquals("006", savedOrder.get().getOrderStatus());
+      assertEquals(1L, savedOrder.get().getVersion());
     }
 
-    @Nested
-    @DisplayName("createOrder")
-    class CreateOrder {
+    /**
+     *
+     *
+     * <pre>
+     * Given 既存注文と X-User-Id を含むリクエストコンテキストを用意する
+     * When 注文をキャンセルする
+     * Then updatedBy にリクエストユーザーが保存される
+     * </pre>
+     */
+    @Test
+    @DisplayName("リクエストヘッダーのユーザー情報が更新監査項目へ反映されること")
+    void shouldUseRequestUserForAuditWhenCancellingOrder() {
+      insertOrder(
+          UUID.fromString("00000000-0000-0000-0000-000000000001"),
+          "ORD000001",
+          OffsetDateTime.parse("2026-04-09T10:15:30+09:00"),
+          "001",
+          0L);
+      MockHttpServletRequest request = new MockHttpServletRequest();
+      request.addHeader("X-User-Id", "operator-1");
+      RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
-        /**
-         * <pre>
-         * Given 注文日時を用意する
-         * When 注文を登録する
-         * Then 注文が保存され注文コードと初期ステータスが設定される
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文を登録できること")
-        void shouldCreateOrder() {
-            Order createdOrder = orderService.createOrder(OrderedAt.of(OffsetDateTime.parse("2026-04-09T10:15:30+09:00")));
+      try {
+        orderService.cancelOrder(OrderCode.of("ORD000001"), Version.of(0L));
 
-            assertEquals("ORD000001", createdOrder.getOrderCode().getValue());
-            assertEquals("2026-04-09T10:15:30+09:00", createdOrder.getOrderedAt().getValue().toString());
-            assertEquals("001", createdOrder.getOrderStatus().getCode());
-            assertEquals(0L, createdOrder.getVersion().getValue());
-
-            Optional<OrderJpaEntity> actual = orderJpaRepository.findByOrderCode(createdOrder.getOrderCode().getValue());
-            assertTrue(actual.isPresent());
-            assertEquals("ORD000001", actual.get().getOrderCode());
-            assertEquals("2026-04-09T10:15:30+09:00", actual.get().getOrderedAt().toString());
-            assertEquals("001", actual.get().getOrderStatus());
-            assertEquals(0L, actual.get().getVersion());
-        }
-
-        /**
-         * <pre>
-         * Given X-User-Id を含むリクエストコンテキストを設定する
-         * When 注文を作成する
-         * Then createdBy と updatedBy にリクエストユーザーが保存される
-         * </pre>
-         */
-        @Test
-        @DisplayName("リクエストヘッダーのユーザー情報が監査項目へ反映されること")
-        void shouldUseRequestUserForAuditWhenCreatingOrder() {
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            request.addHeader("X-User-Id", "user-123");
-            RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
-
-            try {
-                Order createdOrder = orderService.createOrder(OrderedAt.of(OffsetDateTime.parse("2026-04-09T10:15:30+09:00")));
-
-                Optional<OrderJpaEntity> actual = orderJpaRepository.findByOrderCode(createdOrder.getOrderCode().getValue());
-                assertTrue(actual.isPresent());
-                assertEquals("ORD000001", actual.get().getOrderCode());
-                assertEquals("2026-04-09T10:15:30+09:00", actual.get().getOrderedAt().toString());
-                assertEquals("001", actual.get().getOrderStatus());
-                assertEquals(0L, actual.get().getVersion());
-                assertEquals("user-123", actual.get().getCreatedBy());
-                assertEquals("user-123", actual.get().getUpdatedBy());
-            } finally {
-                RequestContextHolder.resetRequestAttributes();
-            }
-        }
+        Optional<OrderJpaEntity> savedOrder = orderJpaRepository.findByOrderCode("ORD000001");
+        assertTrue(savedOrder.isPresent());
+        assertEquals("00000000-0000-0000-0000-000000000001", savedOrder.get().getId().toString());
+        assertEquals("ORD000001", savedOrder.get().getOrderCode());
+        assertEquals("006", savedOrder.get().getOrderStatus());
+        assertEquals(1L, savedOrder.get().getVersion());
+        assertEquals("system", savedOrder.get().getCreatedBy());
+        assertEquals("operator-1", savedOrder.get().getUpdatedBy());
+      } finally {
+        RequestContextHolder.resetRequestAttributes();
+      }
     }
 
-    @Nested
-    @DisplayName("cancelOrder")
-    class CancelOrder {
+    /**
+     *
+     *
+     * <pre>
+     * Given キャンセル対象の注文データが保存されていない
+     * When 注文をキャンセルする
+     * Then 注文未存在例外が発生する
+     * </pre>
+     */
+    @Test
+    @DisplayName("未存在の注文はキャンセルできないこと")
+    void shouldThrowExceptionWhenCancelTargetDoesNotExist() {
+      OrderCode orderCode = OrderCode.of("ORD999999");
+      Version version = Version.of(0L);
 
-        /**
-         * <pre>
-         * Given 注文データが保存されている
-         * When 注文をキャンセルする
-         * Then 注文ステータスがキャンセルで保存される
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文をキャンセルできること")
-        void shouldCancelOrder() {
-            insertOrder(
-                UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                "ORD000001",
-                OffsetDateTime.parse("2026-04-09T10:15:30+09:00"),
-                "001",
-                0L
-            );
+      OrderNotFoundException actual =
+          assertThrows(
+              OrderNotFoundException.class, () -> orderService.cancelOrder(orderCode, version));
 
-            Order actual = orderService.cancelOrder(OrderCode.of("ORD000001"), Version.of(0L));
-
-            assertEquals("00000000-0000-0000-0000-000000000001", actual.getOrderId().getValue().toString());
-            assertEquals("ORD000001", actual.getOrderCode().getValue());
-            assertEquals("2026-04-09T01:15:30Z", actual.getOrderedAt().getValue().toInstant().toString());
-            assertEquals("006", actual.getOrderStatus().getCode());
-            assertEquals(1L, actual.getVersion().getValue());
-
-            Optional<OrderJpaEntity> savedOrder = orderJpaRepository.findByOrderCode("ORD000001");
-            assertTrue(savedOrder.isPresent());
-            assertEquals("00000000-0000-0000-0000-000000000001", savedOrder.get().getId().toString());
-            assertEquals("ORD000001", savedOrder.get().getOrderCode());
-            assertEquals("2026-04-09T01:15:30Z", savedOrder.get().getOrderedAt().toInstant().toString());
-            assertEquals("006", savedOrder.get().getOrderStatus());
-            assertEquals(1L, savedOrder.get().getVersion());
-        }
-
-        /**
-         * <pre>
-         * Given 既存注文と X-User-Id を含むリクエストコンテキストを用意する
-         * When 注文をキャンセルする
-         * Then updatedBy にリクエストユーザーが保存される
-         * </pre>
-         */
-        @Test
-        @DisplayName("リクエストヘッダーのユーザー情報が更新監査項目へ反映されること")
-        void shouldUseRequestUserForAuditWhenCancellingOrder() {
-            insertOrder(
-                UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                "ORD000001",
-                OffsetDateTime.parse("2026-04-09T10:15:30+09:00"),
-                "001",
-                0L
-            );
-            MockHttpServletRequest request = new MockHttpServletRequest();
-            request.addHeader("X-User-Id", "operator-1");
-            RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
-
-            try {
-                orderService.cancelOrder(OrderCode.of("ORD000001"), Version.of(0L));
-
-                Optional<OrderJpaEntity> savedOrder = orderJpaRepository.findByOrderCode("ORD000001");
-                assertTrue(savedOrder.isPresent());
-                assertEquals("00000000-0000-0000-0000-000000000001", savedOrder.get().getId().toString());
-                assertEquals("ORD000001", savedOrder.get().getOrderCode());
-                assertEquals("006", savedOrder.get().getOrderStatus());
-                assertEquals(1L, savedOrder.get().getVersion());
-                assertEquals("system", savedOrder.get().getCreatedBy());
-                assertEquals("operator-1", savedOrder.get().getUpdatedBy());
-            } finally {
-                RequestContextHolder.resetRequestAttributes();
-            }
-        }
-
-        /**
-         * <pre>
-         * Given キャンセル対象の注文データが保存されていない
-         * When 注文をキャンセルする
-         * Then 注文未存在例外が発生する
-         * </pre>
-         */
-        @Test
-        @DisplayName("未存在の注文はキャンセルできないこと")
-        void shouldThrowExceptionWhenCancelTargetDoesNotExist() {
-            OrderCode orderCode = OrderCode.of("ORD999999");
-            Version version = Version.of(0L);
-
-            OrderNotFoundException actual = assertThrows(
-                OrderNotFoundException.class,
-                () -> orderService.cancelOrder(orderCode, version)
-            );
-
-            assertEquals("注文が見つかりません: orderCode=ORD999999", actual.getMessage());
-        }
-
-        /**
-         * <pre>
-         * Given 完了状態の注文データが保存されている
-         * When 注文をキャンセルする
-         * Then 注文キャンセル不可例外が発生する
-         * </pre>
-         */
-        @Test
-        @DisplayName("完了済み注文はキャンセルできないこと")
-        void shouldThrowExceptionWhenCompletedOrderIsCancelled() {
-            insertOrder(
-                UUID.fromString("00000000-0000-0000-0000-000000000001"),
-                "ORD000001",
-                OffsetDateTime.parse("2026-04-09T10:15:30+09:00"),
-                "005",
-                0L
-            );
-            OrderCode orderCode = OrderCode.of("ORD000001");
-            Version version = Version.of(0L);
-
-            OrderCannotBeCancelledException actual = assertThrows(
-                OrderCannotBeCancelledException.class,
-                () -> orderService.cancelOrder(orderCode, version)
-            );
-
-            assertEquals(
-                "注文をキャンセルできません: orderId=00000000-0000-0000-0000-000000000001, orderCode=ORD000001, status=COMPLETED",
-                actual.getMessage()
-            );
-        }
-
-        /**
-         * <pre>
-         * Given 対象注文データが保存されている
-         * When 不一致のバージョンで注文をキャンセルする
-         * Then 注文楽観的ロック競合例外が発生する
-         * </pre>
-         */
-        @Test
-        @DisplayName("不一致のバージョンでキャンセルした場合は競合例外が発生すること")
-        void shouldThrowExceptionWhenVersionDoesNotMatch() {
-            insertOrder(
-                UUID.fromString("00000000-0000-0000-0000-000000000002"),
-                "ORD000001",
-                OffsetDateTime.parse("2026-04-09T10:15:30+09:00"),
-                "001",
-                0L
-            );
-            OrderCode orderCode = OrderCode.of("ORD000001");
-            Version version = Version.of(1L);
-
-            OrderVersionConflictException actual = assertThrows(
-                OrderVersionConflictException.class,
-                () -> orderService.cancelOrder(orderCode, version)
-            );
-
-            assertEquals(
-                "注文のバージョンが競合しています: orderId=00000000-0000-0000-0000-000000000002, orderCode=ORD000001, currentVersion=0, requestedVersion=1",
-                actual.getMessage()
-            );
-        }
+      assertEquals("注文が見つかりません: orderCode=ORD999999", actual.getMessage());
     }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 完了状態の注文データが保存されている
+     * When 注文をキャンセルする
+     * Then 注文キャンセル不可例外が発生する
+     * </pre>
+     */
+    @Test
+    @DisplayName("完了済み注文はキャンセルできないこと")
+    void shouldThrowExceptionWhenCompletedOrderIsCancelled() {
+      insertOrder(
+          UUID.fromString("00000000-0000-0000-0000-000000000001"),
+          "ORD000001",
+          OffsetDateTime.parse("2026-04-09T10:15:30+09:00"),
+          "005",
+          0L);
+      OrderCode orderCode = OrderCode.of("ORD000001");
+      Version version = Version.of(0L);
+
+      OrderCannotBeCancelledException actual =
+          assertThrows(
+              OrderCannotBeCancelledException.class,
+              () -> orderService.cancelOrder(orderCode, version));
+
+      assertEquals(
+          "注文をキャンセルできません: orderId=00000000-0000-0000-0000-000000000001, orderCode=ORD000001,"
+              + " status=COMPLETED",
+          actual.getMessage());
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 対象注文データが保存されている
+     * When 不一致のバージョンで注文をキャンセルする
+     * Then 注文楽観的ロック競合例外が発生する
+     * </pre>
+     */
+    @Test
+    @DisplayName("不一致のバージョンでキャンセルした場合は競合例外が発生すること")
+    void shouldThrowExceptionWhenVersionDoesNotMatch() {
+      insertOrder(
+          UUID.fromString("00000000-0000-0000-0000-000000000002"),
+          "ORD000001",
+          OffsetDateTime.parse("2026-04-09T10:15:30+09:00"),
+          "001",
+          0L);
+      OrderCode orderCode = OrderCode.of("ORD000001");
+      Version version = Version.of(1L);
+
+      OrderVersionConflictException actual =
+          assertThrows(
+              OrderVersionConflictException.class,
+              () -> orderService.cancelOrder(orderCode, version));
+
+      assertEquals(
+          "注文のバージョンが競合しています: orderId=00000000-0000-0000-0000-000000000002, orderCode=ORD000001,"
+              + " currentVersion=0, requestedVersion=1",
+          actual.getMessage());
+    }
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/common/PageResultTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/common/PageResultTest.java
@@ -1,222 +1,217 @@
 package jp.co.shimizutdev.phoneorderapi.domain.common;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-/**
- * ページング済み検索結果テスト
- */
+/** ページング済み検索結果テスト */
 class PageResultTest {
 
-    /**
-     * <pre>
-     * Given ページング済み検索結果の全項目を用意する
-     * When ページング済み検索結果を生成する
-     * Then 全項目とページ有無が保持される
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページング済み検索結果を生成できること")
-    void shouldCreatePageResult() {
-        PageResult<String> actual = new PageResult<>(
-            List.of("ORD000003", "ORD000002"),
-            0,
-            2,
-            3L,
-            2
-        );
+  /**
+   *
+   *
+   * <pre>
+   * Given ページング済み検索結果の全項目を用意する
+   * When ページング済み検索結果を生成する
+   * Then 全項目とページ有無が保持される
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページング済み検索結果を生成できること")
+  void shouldCreatePageResult() {
+    PageResult<String> actual = new PageResult<>(List.of("ORD000003", "ORD000002"), 0, 2, 3L, 2);
 
-        assertEquals(2, actual.items().size());
-        assertEquals("ORD000003", actual.items().get(0));
-        assertEquals("ORD000002", actual.items().get(1));
-        assertEquals(0, actual.page());
-        assertEquals(2, actual.size());
-        assertEquals(3L, actual.totalElements());
-        assertEquals(2, actual.totalPages());
-        assertTrue(actual.hasNext());
-        assertFalse(actual.hasPrevious());
-    }
+    assertEquals(2, actual.items().size());
+    assertEquals("ORD000003", actual.items().get(0));
+    assertEquals("ORD000002", actual.items().get(1));
+    assertEquals(0, actual.page());
+    assertEquals(2, actual.size());
+    assertEquals(3L, actual.totalElements());
+    assertEquals(2, actual.totalPages());
+    assertTrue(actual.hasNext());
+    assertFalse(actual.hasPrevious());
+  }
 
-    /**
-     * <pre>
-     * Given 生成後に変更される要素一覧を用意する
-     * When ページング済み検索結果を生成する
-     * Then 要素一覧は生成時点の内容から変更されない
-     * </pre>
-     */
-    @Test
-    @DisplayName("要素一覧が防御的コピーされること")
-    void shouldDefensivelyCopyItems() {
-        List<String> items = new ArrayList<>();
-        items.add("ORD000001");
+  /**
+   *
+   *
+   * <pre>
+   * Given 生成後に変更される要素一覧を用意する
+   * When ページング済み検索結果を生成する
+   * Then 要素一覧は生成時点の内容から変更されない
+   * </pre>
+   */
+  @Test
+  @DisplayName("要素一覧が防御的コピーされること")
+  void shouldDefensivelyCopyItems() {
+    List<String> items = new ArrayList<>();
+    items.add("ORD000001");
 
-        PageResult<String> actual = new PageResult<>(items, 0, 1, 1L, 1);
-        items.add("ORD000002");
+    PageResult<String> actual = new PageResult<>(items, 0, 1, 1L, 1);
+    items.add("ORD000002");
 
-        assertEquals(1, actual.items().size());
-        assertEquals("ORD000001", actual.items().getFirst());
-    }
+    assertEquals(1, actual.items().size());
+    assertEquals("ORD000001", actual.items().getFirst());
+  }
 
-    /**
-     * <pre>
-     * Given null の要素一覧を用意する
-     * When ページング済み検索結果を生成する
-     * Then 要素一覧必須例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("要素一覧がnullの場合は例外になること")
-    void shouldThrowExceptionWhenItemsIsNull() {
-        NullPointerException actual = assertThrows(
-            NullPointerException.class,
-            () -> new PageResult<>(null, 0, 20, 0L, 0)
-        );
+  /**
+   *
+   *
+   * <pre>
+   * Given null の要素一覧を用意する
+   * When ページング済み検索結果を生成する
+   * Then 要素一覧必須例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("要素一覧がnullの場合は例外になること")
+  void shouldThrowExceptionWhenItemsIsNull() {
+    NullPointerException actual =
+        assertThrows(NullPointerException.class, () -> new PageResult<>(null, 0, 20, 0L, 0));
 
-        assertEquals("要素一覧は必須です。", actual.getMessage());
-    }
+    assertEquals("要素一覧は必須です。", actual.getMessage());
+  }
 
-    /**
-     * <pre>
-     * Given 負のページ番号を用意する
-     * When ページング済み検索結果を生成する
-     * Then ページ番号不正例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページ番号が負の場合は例外になること")
-    void shouldThrowExceptionWhenPageIsNegative() {
-        List<String> items = List.of();
+  /**
+   *
+   *
+   * <pre>
+   * Given 負のページ番号を用意する
+   * When ページング済み検索結果を生成する
+   * Then ページ番号不正例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページ番号が負の場合は例外になること")
+  void shouldThrowExceptionWhenPageIsNegative() {
+    List<String> items = List.of();
 
-        IllegalArgumentException actual = assertThrows(
-            IllegalArgumentException.class,
-            () -> new PageResult<>(items, -1, 20, 0L, 0)
-        );
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> new PageResult<>(items, -1, 20, 0L, 0));
 
-        assertEquals("ページ番号は0以上である必要があります。", actual.getMessage());
-    }
+    assertEquals("ページ番号は0以上である必要があります。", actual.getMessage());
+  }
 
-    /**
-     * <pre>
-     * Given 0 のページサイズを用意する
-     * When ページング済み検索結果を生成する
-     * Then ページサイズ下限不正例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページサイズが1未満の場合は例外になること")
-    void shouldThrowExceptionWhenSizeIsLessThanOne() {
-        List<String> items = List.of();
+  /**
+   *
+   *
+   * <pre>
+   * Given 0 のページサイズを用意する
+   * When ページング済み検索結果を生成する
+   * Then ページサイズ下限不正例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページサイズが1未満の場合は例外になること")
+  void shouldThrowExceptionWhenSizeIsLessThanOne() {
+    List<String> items = List.of();
 
-        IllegalArgumentException actual = assertThrows(
-            IllegalArgumentException.class,
-            () -> new PageResult<>(items, 0, 0, 0L, 0)
-        );
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> new PageResult<>(items, 0, 0, 0L, 0));
 
-        assertEquals("ページサイズは1以上である必要があります。", actual.getMessage());
-    }
+    assertEquals("ページサイズは1以上である必要があります。", actual.getMessage());
+  }
 
-    /**
-     * <pre>
-     * Given 最大値を超えるページサイズを用意する
-     * When ページング済み検索結果を生成する
-     * Then ページサイズ上限不正例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページサイズが最大値を超える場合は例外になること")
-    void shouldThrowExceptionWhenSizeExceedsMaxSize() {
-        List<String> items = List.of();
+  /**
+   *
+   *
+   * <pre>
+   * Given 最大値を超えるページサイズを用意する
+   * When ページング済み検索結果を生成する
+   * Then ページサイズ上限不正例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページサイズが最大値を超える場合は例外になること")
+  void shouldThrowExceptionWhenSizeExceedsMaxSize() {
+    List<String> items = List.of();
 
-        IllegalArgumentException actual = assertThrows(
-            IllegalArgumentException.class,
-            () -> new PageResult<>(items, 0, 101, 0L, 0)
-        );
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> new PageResult<>(items, 0, 101, 0L, 0));
 
-        assertEquals("ページサイズは100以下である必要があります。", actual.getMessage());
-    }
+    assertEquals("ページサイズは100以下である必要があります。", actual.getMessage());
+  }
 
-    /**
-     * <pre>
-     * Given 負の総件数を用意する
-     * When ページング済み検索結果を生成する
-     * Then 総件数不正例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("総件数が負の場合は例外になること")
-    void shouldThrowExceptionWhenTotalElementsIsNegative() {
-        List<String> items = List.of();
+  /**
+   *
+   *
+   * <pre>
+   * Given 負の総件数を用意する
+   * When ページング済み検索結果を生成する
+   * Then 総件数不正例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("総件数が負の場合は例外になること")
+  void shouldThrowExceptionWhenTotalElementsIsNegative() {
+    List<String> items = List.of();
 
-        IllegalArgumentException actual = assertThrows(
-            IllegalArgumentException.class,
-            () -> new PageResult<>(items, 0, 20, -1L, 0)
-        );
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> new PageResult<>(items, 0, 20, -1L, 0));
 
-        assertEquals("総件数は0以上である必要があります。", actual.getMessage());
-    }
+    assertEquals("総件数は0以上である必要があります。", actual.getMessage());
+  }
 
-    /**
-     * <pre>
-     * Given 負の総ページ数を用意する
-     * When ページング済み検索結果を生成する
-     * Then 総ページ数不正例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("総ページ数が負の場合は例外になること")
-    void shouldThrowExceptionWhenTotalPagesIsNegative() {
-        List<String> items = List.of();
+  /**
+   *
+   *
+   * <pre>
+   * Given 負の総ページ数を用意する
+   * When ページング済み検索結果を生成する
+   * Then 総ページ数不正例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("総ページ数が負の場合は例外になること")
+  void shouldThrowExceptionWhenTotalPagesIsNegative() {
+    List<String> items = List.of();
 
-        IllegalArgumentException actual = assertThrows(
-            IllegalArgumentException.class,
-            () -> new PageResult<>(items, 0, 20, 0L, -1)
-        );
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> new PageResult<>(items, 0, 20, 0L, -1));
 
-        assertEquals("総ページ数は0以上である必要があります。", actual.getMessage());
-    }
+    assertEquals("総ページ数は0以上である必要があります。", actual.getMessage());
+  }
 
-    /**
-     * <pre>
-     * Given ページサイズを超える要素一覧を用意する
-     * When ページング済み検索結果を生成する
-     * Then 要素数不正例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("要素数がページサイズを超える場合は例外になること")
-    void shouldThrowExceptionWhenItemsSizeExceedsPageSize() {
-        List<String> items = List.of("ORD000001", "ORD000002");
+  /**
+   *
+   *
+   * <pre>
+   * Given ページサイズを超える要素一覧を用意する
+   * When ページング済み検索結果を生成する
+   * Then 要素数不正例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("要素数がページサイズを超える場合は例外になること")
+  void shouldThrowExceptionWhenItemsSizeExceedsPageSize() {
+    List<String> items = List.of("ORD000001", "ORD000002");
 
-        IllegalArgumentException actual = assertThrows(
-            IllegalArgumentException.class,
-            () -> new PageResult<>(items, 0, 1, 2L, 2)
-        );
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> new PageResult<>(items, 0, 1, 2L, 2));
 
-        assertEquals("要素数はページサイズ以下である必要があります。", actual.getMessage());
-    }
+    assertEquals("要素数はページサイズ以下である必要があります。", actual.getMessage());
+  }
 
-    /**
-     * <pre>
-     * Given 総件数とページサイズに一致しない総ページ数を用意する
-     * When ページング済み検索結果を生成する
-     * Then 総ページ数整合性例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("総ページ数が総件数とページサイズから算出される値と一致しない場合は例外になること")
-    void shouldThrowExceptionWhenTotalPagesDoesNotMatchTotalElementsAndSize() {
-        List<String> items = List.of("ORD000001", "ORD000002");
+  /**
+   *
+   *
+   * <pre>
+   * Given 総件数とページサイズに一致しない総ページ数を用意する
+   * When ページング済み検索結果を生成する
+   * Then 総ページ数整合性例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("総ページ数が総件数とページサイズから算出される値と一致しない場合は例外になること")
+  void shouldThrowExceptionWhenTotalPagesDoesNotMatchTotalElementsAndSize() {
+    List<String> items = List.of("ORD000001", "ORD000002");
 
-        IllegalArgumentException actual = assertThrows(
-            IllegalArgumentException.class,
-            () -> new PageResult<>(items, 0, 2, 3L, 1)
-        );
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> new PageResult<>(items, 0, 2, 3L, 1));
 
-        assertEquals("総ページ数は総件数とページサイズから算出される値と一致する必要があります。", actual.getMessage());
-    }
+    assertEquals("総ページ数は総件数とページサイズから算出される値と一致する必要があります。", actual.getMessage());
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/common/PagingConditionTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/common/PagingConditionTest.java
@@ -1,131 +1,137 @@
 package jp.co.shimizutdev.phoneorderapi.domain.common;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * ページング条件テスト
- */
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** ページング条件テスト */
 class PagingConditionTest {
 
-    /**
-     * <pre>
-     * Given ページ番号とページサイズを用意する
-     * When ページング条件を生成する
-     * Then 指定したページ番号とページサイズが保持される
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページング条件を生成できること")
-    void shouldCreatePagingCondition() {
-        PagingCondition actual = PagingCondition.of(1, 50);
+  /**
+   *
+   *
+   * <pre>
+   * Given ページ番号とページサイズを用意する
+   * When ページング条件を生成する
+   * Then 指定したページ番号とページサイズが保持される
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページング条件を生成できること")
+  void shouldCreatePagingCondition() {
+    PagingCondition actual = PagingCondition.of(1, 50);
 
-        assertEquals(1, actual.page());
-        assertEquals(50, actual.size());
-    }
+    assertEquals(1, actual.page());
+    assertEquals(50, actual.size());
+  }
 
-    /**
-     * <pre>
-     * Given null のページ番号とページサイズを用意する
-     * When 未指定値を補完してページング条件を生成する
-     * Then デフォルトページ番号とデフォルトページサイズが設定される
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページ番号とページサイズがnullの場合はデフォルト値で補完されること")
-    void shouldUseDefaultValuesWhenPageAndSizeAreNull() {
-        PagingCondition actual = PagingCondition.ofNullable(null, null);
+  /**
+   *
+   *
+   * <pre>
+   * Given null のページ番号とページサイズを用意する
+   * When 未指定値を補完してページング条件を生成する
+   * Then デフォルトページ番号とデフォルトページサイズが設定される
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページ番号とページサイズがnullの場合はデフォルト値で補完されること")
+  void shouldUseDefaultValuesWhenPageAndSizeAreNull() {
+    PagingCondition actual = PagingCondition.ofNullable(null, null);
 
-        assertEquals(0, actual.page());
-        assertEquals(20, actual.size());
-    }
+    assertEquals(0, actual.page());
+    assertEquals(20, actual.size());
+  }
 
-    /**
-     * <pre>
-     * Given null のページ番号とページサイズ指定を用意する
-     * When 未指定値を補完してページング条件を生成する
-     * Then ページ番号だけデフォルト値で補完される
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページ番号がnullの場合はデフォルトページ番号で補完されること")
-    void shouldUseDefaultPageWhenPageIsNull() {
-        PagingCondition actual = PagingCondition.ofNullable(null, 50);
+  /**
+   *
+   *
+   * <pre>
+   * Given null のページ番号とページサイズ指定を用意する
+   * When 未指定値を補完してページング条件を生成する
+   * Then ページ番号だけデフォルト値で補完される
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページ番号がnullの場合はデフォルトページ番号で補完されること")
+  void shouldUseDefaultPageWhenPageIsNull() {
+    PagingCondition actual = PagingCondition.ofNullable(null, 50);
 
-        assertEquals(0, actual.page());
-        assertEquals(50, actual.size());
-    }
+    assertEquals(0, actual.page());
+    assertEquals(50, actual.size());
+  }
 
-    /**
-     * <pre>
-     * Given ページ番号指定と null のページサイズを用意する
-     * When 未指定値を補完してページング条件を生成する
-     * Then ページサイズだけデフォルト値で補完される
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページサイズがnullの場合はデフォルトページサイズで補完されること")
-    void shouldUseDefaultSizeWhenSizeIsNull() {
-        PagingCondition actual = PagingCondition.ofNullable(1, null);
+  /**
+   *
+   *
+   * <pre>
+   * Given ページ番号指定と null のページサイズを用意する
+   * When 未指定値を補完してページング条件を生成する
+   * Then ページサイズだけデフォルト値で補完される
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページサイズがnullの場合はデフォルトページサイズで補完されること")
+  void shouldUseDefaultSizeWhenSizeIsNull() {
+    PagingCondition actual = PagingCondition.ofNullable(1, null);
 
-        assertEquals(1, actual.page());
-        assertEquals(20, actual.size());
-    }
+    assertEquals(1, actual.page());
+    assertEquals(20, actual.size());
+  }
 
-    /**
-     * <pre>
-     * Given 負のページ番号を用意する
-     * When ページング条件を生成する
-     * Then ページ番号不正例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページ番号が負の場合は例外になること")
-    void shouldThrowExceptionWhenPageIsNegative() {
-        IllegalArgumentException actual = assertThrows(
-            IllegalArgumentException.class,
-            () -> PagingCondition.of(-1, 20)
-        );
+  /**
+   *
+   *
+   * <pre>
+   * Given 負のページ番号を用意する
+   * When ページング条件を生成する
+   * Then ページ番号不正例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページ番号が負の場合は例外になること")
+  void shouldThrowExceptionWhenPageIsNegative() {
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> PagingCondition.of(-1, 20));
 
-        assertEquals("ページ番号は0以上である必要があります。", actual.getMessage());
-    }
+    assertEquals("ページ番号は0以上である必要があります。", actual.getMessage());
+  }
 
-    /**
-     * <pre>
-     * Given 0 のページサイズを用意する
-     * When ページング条件を生成する
-     * Then ページサイズ下限不正例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページサイズが1未満の場合は例外になること")
-    void shouldThrowExceptionWhenSizeIsLessThanOne() {
-        IllegalArgumentException actual = assertThrows(
-            IllegalArgumentException.class,
-            () -> PagingCondition.of(0, 0)
-        );
+  /**
+   *
+   *
+   * <pre>
+   * Given 0 のページサイズを用意する
+   * When ページング条件を生成する
+   * Then ページサイズ下限不正例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページサイズが1未満の場合は例外になること")
+  void shouldThrowExceptionWhenSizeIsLessThanOne() {
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> PagingCondition.of(0, 0));
 
-        assertEquals("ページサイズは1以上である必要があります。", actual.getMessage());
-    }
+    assertEquals("ページサイズは1以上である必要があります。", actual.getMessage());
+  }
 
-    /**
-     * <pre>
-     * Given 最大値を超えるページサイズを用意する
-     * When ページング条件を生成する
-     * Then ページサイズ上限不正例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("ページサイズが最大値を超える場合は例外になること")
-    void shouldThrowExceptionWhenSizeExceedsMaxSize() {
-        IllegalArgumentException actual = assertThrows(
-            IllegalArgumentException.class,
-            () -> PagingCondition.of(0, 101)
-        );
+  /**
+   *
+   *
+   * <pre>
+   * Given 最大値を超えるページサイズを用意する
+   * When ページング条件を生成する
+   * Then ページサイズ上限不正例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("ページサイズが最大値を超える場合は例外になること")
+  void shouldThrowExceptionWhenSizeExceedsMaxSize() {
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> PagingCondition.of(0, 101));
 
-        assertEquals("ページサイズは100以下である必要があります。", actual.getMessage());
-    }
+    assertEquals("ページサイズは100以下である必要があります。", actual.getMessage());
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderCodeTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderCodeTest.java
@@ -1,5 +1,8 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -7,45 +10,44 @@ import org.junit.jupiter.params.provider.EmptySource;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-/**
- * 注文コードテスト
- */
+/** 注文コードテスト */
 class OrderCodeTest {
 
-    /**
-     * <pre>
-     * Given 正常な注文コードを用意する
-     * When 注文コードを生成する
-     * Then 注文コードが生成される
-     * </pre>
-     */
-    @Test
-    @DisplayName("正常な注文コードを生成できること")
-    void shouldCreateOrderCodeWhenFormatIsValid() {
-        OrderCode actual = OrderCode.of("ORD000001");
+  /**
+   *
+   *
+   * <pre>
+   * Given 正常な注文コードを用意する
+   * When 注文コードを生成する
+   * Then 注文コードが生成される
+   * </pre>
+   */
+  @Test
+  @DisplayName("正常な注文コードを生成できること")
+  void shouldCreateOrderCodeWhenFormatIsValid() {
+    OrderCode actual = OrderCode.of("ORD000001");
 
-        assertEquals("ORD000001", actual.getValue());
-    }
+    assertEquals("ORD000001", actual.getValue());
+  }
 
-    /**
-     * <pre>
-     * Given 不正な形式の注文コードを用意する
-     * When 注文コードを生成する
-     * Then 例外が発生する
-     * </pre>
-     */
-    @ParameterizedTest
-    @NullSource
-    @EmptySource
-    @ValueSource(strings = {"   ", "ABC000001", "ORD00001"})
-    @DisplayName("不正な形式の注文コードを生成しようとすると例外が発生すること")
-    void shouldThrowExceptionWhenOrderCodeFormatIsInvalid(final String value) {
-        IllegalArgumentException actual =
-            assertThrows(IllegalArgumentException.class, () -> OrderCode.of(value));
+  /**
+   *
+   *
+   * <pre>
+   * Given 不正な形式の注文コードを用意する
+   * When 注文コードを生成する
+   * Then 例外が発生する
+   * </pre>
+   */
+  @ParameterizedTest
+  @NullSource
+  @EmptySource
+  @ValueSource(strings = {"   ", "ABC000001", "ORD00001"})
+  @DisplayName("不正な形式の注文コードを生成しようとすると例外が発生すること")
+  void shouldThrowExceptionWhenOrderCodeFormatIsInvalid(final String value) {
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> OrderCode.of(value));
 
-        assertEquals("注文コード（ORD000001）の形式と不一致です。", actual.getMessage());
-    }
+    assertEquals("注文コード（ORD000001）の形式と不一致です。", actual.getMessage());
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepositoryTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderRepositoryTest.java
@@ -1,6 +1,11 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import jakarta.persistence.EntityManager;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import java.util.UUID;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PageResult;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PagingCondition;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.config.JpaAuditConfig;
@@ -17,321 +22,357 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
-import java.time.OffsetDateTime;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-/**
- * 注文リポジトリテスト
- */
+/** 注文リポジトリテスト */
 @DataJpaTest(showSql = false)
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Import({JpaAuditConfig.class, OrderRepositoryImpl.class})
 class OrderRepositoryTest extends AbstractPostgreSQLTest {
 
-    /**
-     * 注文リポジトリ
-     */
-    @Autowired
-    private OrderRepository orderRepository;
+  /** 注文リポジトリ */
+  @Autowired private OrderRepository orderRepository;
 
-    /**
-     * 注文JPAリポジトリ
-     */
-    @Autowired
-    private OrderJpaRepository orderJpaRepository;
+  /** 注文JPAリポジトリ */
+  @Autowired private OrderJpaRepository orderJpaRepository;
 
-    /**
-     * エンティティマネージャ
-     */
-    @Autowired
-    private EntityManager entityManager;
+  /** エンティティマネージャ */
+  @Autowired private EntityManager entityManager;
 
-    /**
-     * テスト実行前処理
-     */
-    @BeforeEach
-    void setUp() {
-        orderJpaRepository.deleteAll();
-    }
+  /** テスト実行前処理 */
+  @BeforeEach
+  void setUp() {
+    orderJpaRepository.deleteAll();
+  }
 
-    /**
-     * テスト実行後処理
-     */
-    @AfterEach
-    void tearDown() {
-        orderJpaRepository.deleteAll();
-    }
+  /** テスト実行後処理 */
+  @AfterEach
+  void tearDown() {
+    orderJpaRepository.deleteAll();
+  }
 
-    /**
-     * <pre>
-     * Given 注文データが複数件登録されている
-     * When ページング条件を指定して注文一覧を取得する
-     * Then 注文日時降順、同一日時は注文コード降順のページング済み注文一覧とページ情報が返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("注文一覧を注文日時降順かつ注文コード降順で取得できること")
-    void shouldFindAllOrders() {
-        OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
-        insertOrder(UUID.fromString("00000000-0000-0000-0000-000000000001"), "ORD000001", orderedAt, "001", 0L);
-        insertOrder(UUID.fromString("00000000-0000-0000-0000-000000000002"), "ORD000002", orderedAt, "002", 1L);
+  /**
+   *
+   *
+   * <pre>
+   * Given 注文データが複数件登録されている
+   * When ページング条件を指定して注文一覧を取得する
+   * Then 注文日時降順、同一日時は注文コード降順のページング済み注文一覧とページ情報が返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("注文一覧を注文日時降順かつ注文コード降順で取得できること")
+  void shouldFindAllOrders() {
+    OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
+    insertOrder(
+        UUID.fromString("00000000-0000-0000-0000-000000000001"), "ORD000001", orderedAt, "001", 0L);
+    insertOrder(
+        UUID.fromString("00000000-0000-0000-0000-000000000002"), "ORD000002", orderedAt, "002", 1L);
 
-        PageResult<Order> actual = orderRepository.findAll(PagingCondition.of(0, 20));
+    PageResult<Order> actual = orderRepository.findAll(PagingCondition.of(0, 20));
 
-        assertEquals(2, actual.items().size());
-        assertEquals("00000000-0000-0000-0000-000000000002", actual.items().getFirst().getOrderId().getValue().toString());
-        assertEquals("ORD000002", actual.items().getFirst().getOrderCode().getValue());
-        assertEquals("2026-04-09T01:15:30Z", actual.items().getFirst().getOrderedAt().getValue().toInstant().toString());
-        assertEquals("002", actual.items().getFirst().getOrderStatus().getCode());
-        assertEquals(1L, actual.items().getFirst().getVersion().getValue());
-        assertEquals("00000000-0000-0000-0000-000000000001", actual.items().get(1).getOrderId().getValue().toString());
-        assertEquals("ORD000001", actual.items().get(1).getOrderCode().getValue());
-        assertEquals("2026-04-09T01:15:30Z", actual.items().get(1).getOrderedAt().getValue().toInstant().toString());
-        assertEquals("001", actual.items().get(1).getOrderStatus().getCode());
-        assertEquals(0L, actual.items().get(1).getVersion().getValue());
-        assertEquals(0, actual.page());
-        assertEquals(20, actual.size());
-        assertEquals(2, actual.totalElements());
-        assertEquals(1, actual.totalPages());
-        assertFalse(actual.hasNext());
-        assertFalse(actual.hasPrevious());
-    }
+    assertEquals(2, actual.items().size());
+    assertEquals(
+        "00000000-0000-0000-0000-000000000002",
+        actual.items().getFirst().getOrderId().getValue().toString());
+    assertEquals("ORD000002", actual.items().getFirst().getOrderCode().getValue());
+    assertEquals(
+        "2026-04-09T01:15:30Z",
+        actual.items().getFirst().getOrderedAt().getValue().toInstant().toString());
+    assertEquals("002", actual.items().getFirst().getOrderStatus().getCode());
+    assertEquals(1L, actual.items().getFirst().getVersion().getValue());
+    assertEquals(
+        "00000000-0000-0000-0000-000000000001",
+        actual.items().get(1).getOrderId().getValue().toString());
+    assertEquals("ORD000001", actual.items().get(1).getOrderCode().getValue());
+    assertEquals(
+        "2026-04-09T01:15:30Z",
+        actual.items().get(1).getOrderedAt().getValue().toInstant().toString());
+    assertEquals("001", actual.items().get(1).getOrderStatus().getCode());
+    assertEquals(0L, actual.items().get(1).getVersion().getValue());
+    assertEquals(0, actual.page());
+    assertEquals(20, actual.size());
+    assertEquals(2, actual.totalElements());
+    assertEquals(1, actual.totalPages());
+    assertFalse(actual.hasNext());
+    assertFalse(actual.hasPrevious());
+  }
 
-    /**
-     * <pre>
-     * Given 注文データが3件登録されている
-     * When ページング条件を指定して注文一覧を取得する
-     * Then 指定ページの注文一覧とページ情報が返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("注文一覧をページ指定で取得できること")
-    void shouldFindOrdersByPage() {
-        insertOrder(UUID.fromString("00000000-0000-0000-0000-000000000001"), "ORD000001", OffsetDateTime.parse("2026-04-09T10:00:00+09:00"), "001", 0L);
-        insertOrder(UUID.fromString("00000000-0000-0000-0000-000000000002"), "ORD000002", OffsetDateTime.parse("2026-04-09T11:00:00+09:00"), "001", 0L);
-        insertOrder(UUID.fromString("00000000-0000-0000-0000-000000000003"), "ORD000003", OffsetDateTime.parse("2026-04-09T12:00:00+09:00"), "001", 0L);
+  /**
+   *
+   *
+   * <pre>
+   * Given 注文データが3件登録されている
+   * When ページング条件を指定して注文一覧を取得する
+   * Then 指定ページの注文一覧とページ情報が返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("注文一覧をページ指定で取得できること")
+  void shouldFindOrdersByPage() {
+    insertOrder(
+        UUID.fromString("00000000-0000-0000-0000-000000000001"),
+        "ORD000001",
+        OffsetDateTime.parse("2026-04-09T10:00:00+09:00"),
+        "001",
+        0L);
+    insertOrder(
+        UUID.fromString("00000000-0000-0000-0000-000000000002"),
+        "ORD000002",
+        OffsetDateTime.parse("2026-04-09T11:00:00+09:00"),
+        "001",
+        0L);
+    insertOrder(
+        UUID.fromString("00000000-0000-0000-0000-000000000003"),
+        "ORD000003",
+        OffsetDateTime.parse("2026-04-09T12:00:00+09:00"),
+        "001",
+        0L);
 
-        PageResult<Order> actual = orderRepository.findAll(PagingCondition.of(1, 2));
+    PageResult<Order> actual = orderRepository.findAll(PagingCondition.of(1, 2));
 
-        assertEquals(1, actual.items().size());
-        assertEquals("00000000-0000-0000-0000-000000000001", actual.items().getFirst().getOrderId().getValue().toString());
-        assertEquals("ORD000001", actual.items().getFirst().getOrderCode().getValue());
-        assertEquals("2026-04-09T01:00:00Z", actual.items().getFirst().getOrderedAt().getValue().toInstant().toString());
-        assertEquals("001", actual.items().getFirst().getOrderStatus().getCode());
-        assertEquals(0L, actual.items().getFirst().getVersion().getValue());
-        assertEquals(1, actual.page());
-        assertEquals(2, actual.size());
-        assertEquals(3, actual.totalElements());
-        assertEquals(2, actual.totalPages());
-        assertFalse(actual.hasNext());
-        assertTrue(actual.hasPrevious());
-    }
+    assertEquals(1, actual.items().size());
+    assertEquals(
+        "00000000-0000-0000-0000-000000000001",
+        actual.items().getFirst().getOrderId().getValue().toString());
+    assertEquals("ORD000001", actual.items().getFirst().getOrderCode().getValue());
+    assertEquals(
+        "2026-04-09T01:00:00Z",
+        actual.items().getFirst().getOrderedAt().getValue().toInstant().toString());
+    assertEquals("001", actual.items().getFirst().getOrderStatus().getCode());
+    assertEquals(0L, actual.items().getFirst().getVersion().getValue());
+    assertEquals(1, actual.page());
+    assertEquals(2, actual.size());
+    assertEquals(3, actual.totalElements());
+    assertEquals(2, actual.totalPages());
+    assertFalse(actual.hasNext());
+    assertTrue(actual.hasPrevious());
+  }
 
-    /**
-     * <pre>
-     * Given 注文データが2件登録されている
-     * When 総ページ数を超えるページング条件を指定して注文一覧を取得する
-     * Then 空の注文一覧と指定ページのページ情報が返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("範囲外ページは空ページを返すこと")
-    void shouldReturnEmptyPageWhenPageIsOutOfRange() {
-        insertOrder(UUID.fromString("00000000-0000-0000-0000-000000000001"), "ORD000001", OffsetDateTime.parse("2026-04-09T10:00:00+09:00"), "001", 0L);
-        insertOrder(UUID.fromString("00000000-0000-0000-0000-000000000002"), "ORD000002", OffsetDateTime.parse("2026-04-09T11:00:00+09:00"), "001", 0L);
+  /**
+   *
+   *
+   * <pre>
+   * Given 注文データが2件登録されている
+   * When 総ページ数を超えるページング条件を指定して注文一覧を取得する
+   * Then 空の注文一覧と指定ページのページ情報が返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("範囲外ページは空ページを返すこと")
+  void shouldReturnEmptyPageWhenPageIsOutOfRange() {
+    insertOrder(
+        UUID.fromString("00000000-0000-0000-0000-000000000001"),
+        "ORD000001",
+        OffsetDateTime.parse("2026-04-09T10:00:00+09:00"),
+        "001",
+        0L);
+    insertOrder(
+        UUID.fromString("00000000-0000-0000-0000-000000000002"),
+        "ORD000002",
+        OffsetDateTime.parse("2026-04-09T11:00:00+09:00"),
+        "001",
+        0L);
 
-        PageResult<Order> actual = orderRepository.findAll(PagingCondition.of(2, 2));
+    PageResult<Order> actual = orderRepository.findAll(PagingCondition.of(2, 2));
 
-        assertEquals(0, actual.items().size());
-        assertEquals(2, actual.page());
-        assertEquals(2, actual.size());
-        assertEquals(2, actual.totalElements());
-        assertEquals(1, actual.totalPages());
-        assertFalse(actual.hasNext());
-        assertTrue(actual.hasPrevious());
-    }
+    assertEquals(0, actual.items().size());
+    assertEquals(2, actual.page());
+    assertEquals(2, actual.size());
+    assertEquals(2, actual.totalElements());
+    assertEquals(1, actual.totalPages());
+    assertFalse(actual.hasNext());
+    assertTrue(actual.hasPrevious());
+  }
 
-    /**
-     * <pre>
-     * Given 注文データが登録されている
-     * When 注文コードで注文を取得する
-     * Then 対象注文が返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("注文コードで注文を取得できること")
-    void shouldFindOrderByOrderCode() {
-        UUID orderId = UUID.fromString("00000000-0000-0000-0000-000000000001");
-        OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
-        insertOrder(orderId, "ORD000001", orderedAt, "001", 2L);
+  /**
+   *
+   *
+   * <pre>
+   * Given 注文データが登録されている
+   * When 注文コードで注文を取得する
+   * Then 対象注文が返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("注文コードで注文を取得できること")
+  void shouldFindOrderByOrderCode() {
+    UUID orderId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
+    insertOrder(orderId, "ORD000001", orderedAt, "001", 2L);
 
-        Optional<Order> actual = orderRepository.findByOrderCode(OrderCode.of("ORD000001"));
+    Optional<Order> actual = orderRepository.findByOrderCode(OrderCode.of("ORD000001"));
 
-        assertTrue(actual.isPresent());
-        assertEquals("00000000-0000-0000-0000-000000000001", actual.get().getOrderId().getValue().toString());
-        assertEquals("ORD000001", actual.get().getOrderCode().getValue());
-        assertEquals("2026-04-09T01:15:30Z", actual.get().getOrderedAt().getValue().toInstant().toString());
-        assertEquals("001", actual.get().getOrderStatus().getCode());
-        assertEquals(2L, actual.get().getVersion().getValue());
-    }
+    assertTrue(actual.isPresent());
+    assertEquals(
+        "00000000-0000-0000-0000-000000000001", actual.get().getOrderId().getValue().toString());
+    assertEquals("ORD000001", actual.get().getOrderCode().getValue());
+    assertEquals(
+        "2026-04-09T01:15:30Z", actual.get().getOrderedAt().getValue().toInstant().toString());
+    assertEquals("001", actual.get().getOrderStatus().getCode());
+    assertEquals(2L, actual.get().getVersion().getValue());
+  }
 
-    /**
-     * <pre>
-     * Given 注文データが登録されていない
-     * When 注文コードで注文を取得する
-     * Then 空が返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("存在しない注文コードの場合に空を返すこと")
-    void shouldReturnEmptyWhenOrderCodeDoesNotExist() {
-        Optional<Order> actual = orderRepository.findByOrderCode(OrderCode.of("ORD999999"));
+  /**
+   *
+   *
+   * <pre>
+   * Given 注文データが登録されていない
+   * When 注文コードで注文を取得する
+   * Then 空が返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("存在しない注文コードの場合に空を返すこと")
+  void shouldReturnEmptyWhenOrderCodeDoesNotExist() {
+    Optional<Order> actual = orderRepository.findByOrderCode(OrderCode.of("ORD999999"));
 
-        assertTrue(actual.isEmpty());
-    }
+    assertTrue(actual.isEmpty());
+  }
 
-    /**
-     * <pre>
-     * Given 登録対象の注文を用意する
-     * When 注文を登録する
-     * Then 注文が登録される
-     * </pre>
-     */
-    @Test
-    @DisplayName("注文を登録できること")
-    void shouldCreateOrder() {
-        UUID orderId = UUID.fromString("00000000-0000-0000-0000-000000000002");
-        OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
-        Order order = Order.reconstruct(
+  /**
+   *
+   *
+   * <pre>
+   * Given 登録対象の注文を用意する
+   * When 注文を登録する
+   * Then 注文が登録される
+   * </pre>
+   */
+  @Test
+  @DisplayName("注文を登録できること")
+  void shouldCreateOrder() {
+    UUID orderId = UUID.fromString("00000000-0000-0000-0000-000000000002");
+    OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
+    Order order =
+        Order.reconstruct(
             OrderId.of(orderId),
             OrderCode.of("ORD000001"),
             OrderedAt.of(orderedAt),
             OrderStatus.RECEIVED,
-            Version.of(0L)
-        );
+            Version.of(0L));
 
-        Order actual = orderRepository.create(order);
-        entityManager.clear();
+    Order actual = orderRepository.create(order);
+    entityManager.clear();
 
-        assertEquals("00000000-0000-0000-0000-000000000002", actual.getOrderId().getValue().toString());
-        assertEquals("ORD000001", actual.getOrderCode().getValue());
-        assertEquals("2026-04-09T01:15:30Z", actual.getOrderedAt().getValue().toInstant().toString());
-        assertEquals("001", actual.getOrderStatus().getCode());
-        assertEquals(0L, actual.getVersion().getValue());
+    assertEquals("00000000-0000-0000-0000-000000000002", actual.getOrderId().getValue().toString());
+    assertEquals("ORD000001", actual.getOrderCode().getValue());
+    assertEquals("2026-04-09T01:15:30Z", actual.getOrderedAt().getValue().toInstant().toString());
+    assertEquals("001", actual.getOrderStatus().getCode());
+    assertEquals(0L, actual.getVersion().getValue());
 
-        Optional<OrderJpaEntity> savedOrder = orderJpaRepository.findById(orderId);
-        assertTrue(savedOrder.isPresent());
-        assertEquals("ORD000001", savedOrder.get().getOrderCode());
-        assertEquals("001", savedOrder.get().getOrderStatus());
-        assertEquals(0L, savedOrder.get().getVersion());
-    }
+    Optional<OrderJpaEntity> savedOrder = orderJpaRepository.findById(orderId);
+    assertTrue(savedOrder.isPresent());
+    assertEquals("ORD000001", savedOrder.get().getOrderCode());
+    assertEquals("001", savedOrder.get().getOrderStatus());
+    assertEquals(0L, savedOrder.get().getVersion());
+  }
 
-    /**
-     * <pre>
-     * Given 注文データが登録されている
-     * When 注文を更新する
-     * Then 注文ステータスが更新される
-     * </pre>
-     */
-    @Test
-    @DisplayName("注文を更新できること")
-    void shouldUpdateOrder() {
-        UUID orderId = UUID.fromString("00000000-0000-0000-0000-000000000003");
-        OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
-        insertOrder(orderId, "ORD000001", orderedAt, "001", 0L);
+  /**
+   *
+   *
+   * <pre>
+   * Given 注文データが登録されている
+   * When 注文を更新する
+   * Then 注文ステータスが更新される
+   * </pre>
+   */
+  @Test
+  @DisplayName("注文を更新できること")
+  void shouldUpdateOrder() {
+    UUID orderId = UUID.fromString("00000000-0000-0000-0000-000000000003");
+    OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
+    insertOrder(orderId, "ORD000001", orderedAt, "001", 0L);
 
-        Order order = Order.reconstruct(
+    Order order =
+        Order.reconstruct(
             OrderId.of(orderId),
             OrderCode.of("ORD000001"),
             OrderedAt.of(orderedAt),
             OrderStatus.CANCELLED,
-            Version.of(0L)
-        );
+            Version.of(0L));
 
-        Order actual = orderRepository.update(order);
-        entityManager.clear();
+    Order actual = orderRepository.update(order);
+    entityManager.clear();
 
-        assertEquals("00000000-0000-0000-0000-000000000003", actual.getOrderId().getValue().toString());
-        assertEquals("ORD000001", actual.getOrderCode().getValue());
-        assertEquals("2026-04-09T01:15:30Z", actual.getOrderedAt().getValue().toInstant().toString());
-        assertEquals("006", actual.getOrderStatus().getCode());
-        assertEquals(1L, actual.getVersion().getValue());
+    assertEquals("00000000-0000-0000-0000-000000000003", actual.getOrderId().getValue().toString());
+    assertEquals("ORD000001", actual.getOrderCode().getValue());
+    assertEquals("2026-04-09T01:15:30Z", actual.getOrderedAt().getValue().toInstant().toString());
+    assertEquals("006", actual.getOrderStatus().getCode());
+    assertEquals(1L, actual.getVersion().getValue());
 
-        Optional<OrderJpaEntity> savedOrder = orderJpaRepository.findById(orderId);
-        assertTrue(savedOrder.isPresent());
-        assertEquals("00000000-0000-0000-0000-000000000003", savedOrder.get().getId().toString());
-        assertEquals("ORD000001", savedOrder.get().getOrderCode());
-        assertEquals("2026-04-09T01:15:30Z", savedOrder.get().getOrderedAt().toInstant().toString());
-        assertEquals("006", savedOrder.get().getOrderStatus());
-        assertEquals("system", savedOrder.get().getCreatedBy());
-        assertEquals("system", savedOrder.get().getUpdatedBy());
-        assertEquals(1L, savedOrder.get().getVersion());
-    }
+    Optional<OrderJpaEntity> savedOrder = orderJpaRepository.findById(orderId);
+    assertTrue(savedOrder.isPresent());
+    assertEquals("00000000-0000-0000-0000-000000000003", savedOrder.get().getId().toString());
+    assertEquals("ORD000001", savedOrder.get().getOrderCode());
+    assertEquals("2026-04-09T01:15:30Z", savedOrder.get().getOrderedAt().toInstant().toString());
+    assertEquals("006", savedOrder.get().getOrderStatus());
+    assertEquals("system", savedOrder.get().getCreatedBy());
+    assertEquals("system", savedOrder.get().getUpdatedBy());
+    assertEquals(1L, savedOrder.get().getVersion());
+  }
 
-    /**
-     * <pre>
-     * Given version が進んだ注文データが登録されている
-     * When 古い version で注文を更新する
-     * Then 注文の楽観ロック競合例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("stale version で更新すると競合例外になる")
-    void shouldThrowExceptionWhenUpdatingWithStaleVersion() {
-        UUID orderId = UUID.fromString("00000000-0000-0000-0000-000000000004");
-        OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
-        insertOrder(orderId, "ORD000001", orderedAt, "001", 1L);
+  /**
+   *
+   *
+   * <pre>
+   * Given version が進んだ注文データが登録されている
+   * When 古い version で注文を更新する
+   * Then 注文の楽観ロック競合例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("stale version で更新すると競合例外になる")
+  void shouldThrowExceptionWhenUpdatingWithStaleVersion() {
+    UUID orderId = UUID.fromString("00000000-0000-0000-0000-000000000004");
+    OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
+    insertOrder(orderId, "ORD000001", orderedAt, "001", 1L);
 
-        Order order = Order.reconstruct(
+    Order order =
+        Order.reconstruct(
             OrderId.of(orderId),
             OrderCode.of("ORD000001"),
             OrderedAt.of(orderedAt),
             OrderStatus.CANCELLED,
-            Version.of(0L)
-        );
+            Version.of(0L));
 
-        OrderVersionConflictException actual = assertThrows(
-            OrderVersionConflictException.class,
-            () -> orderRepository.update(order)
-        );
+    OrderVersionConflictException actual =
+        assertThrows(OrderVersionConflictException.class, () -> orderRepository.update(order));
 
-        assertEquals(
-            "注文のバージョンが競合しています: orderId=00000000-0000-0000-0000-000000000004, orderCode=ORD000001, version=0",
-            actual.getMessage()
-        );
-    }
+    assertEquals(
+        "注文のバージョンが競合しています: orderId=00000000-0000-0000-0000-000000000004, orderCode=ORD000001,"
+            + " version=0",
+        actual.getMessage());
+  }
 
-    /**
-     * 注文データをDBへ直接登録する
-     *
-     * @param orderId     注文ID
-     * @param orderCode   注文コード
-     * @param orderedAt   注文日時
-     * @param orderStatus 注文ステータス
-     * @param version     バージョン
-     */
-    private void insertOrder(
-        final UUID orderId,
-        final String orderCode,
-        final OffsetDateTime orderedAt,
-        final String orderStatus,
-        final long version) {
+  /**
+   * 注文データをDBへ直接登録する
+   *
+   * @param orderId 注文ID
+   * @param orderCode 注文コード
+   * @param orderedAt 注文日時
+   * @param orderStatus 注文ステータス
+   * @param version バージョン
+   */
+  private void insertOrder(
+      final UUID orderId,
+      final String orderCode,
+      final OffsetDateTime orderedAt,
+      final String orderStatus,
+      final long version) {
 
-        //noinspection SqlResolve,SqlNoDataSourceInspection
-        entityManager.createNativeQuery("""
-                insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by)
-                values (:id, :orderCode, :orderedAt, :orderStatus, :version, 'system', 'system')
-                """)
-            .setParameter("id", orderId)
-            .setParameter("orderCode", orderCode)
-            .setParameter("orderedAt", orderedAt)
-            .setParameter("orderStatus", orderStatus)
-            .setParameter("version", version)
-            .executeUpdate();
-        entityManager.flush();
-        entityManager.clear();
-    }
+    //noinspection SqlResolve,SqlNoDataSourceInspection
+    entityManager
+        .createNativeQuery(
+            """
+insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by)
+values (:id, :orderCode, :orderedAt, :orderStatus, :version, 'system', 'system')
+""")
+        .setParameter("id", orderId)
+        .setParameter("orderCode", orderCode)
+        .setParameter("orderedAt", orderedAt)
+        .setParameter("orderStatus", orderStatus)
+        .setParameter("version", version)
+        .executeUpdate();
+    entityManager.flush();
+    entityManager.clear();
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/OrderTest.java
@@ -1,126 +1,127 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-
-import java.time.OffsetDateTime;
-import java.util.UUID;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-/**
- * 注文ドメインテスト
- */
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/** 注文ドメインテスト */
 class OrderTest {
 
-    /**
-     * <pre>
-     * Given 注文日時と注文コードを用意する
-     * When 注文を登録する
-     * Then 注文コードと注文日時と初期ステータスが設定される
-     * </pre>
-     */
-    @Test
-    @DisplayName("注文を登録できること")
-    void shouldCreateOrder() {
-        OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
-        OrderedAt actualOrderedAt = OrderedAt.of(orderedAt);
-        OrderCode orderCode = OrderCode.of("ORD000001");
+  /**
+   *
+   *
+   * <pre>
+   * Given 注文日時と注文コードを用意する
+   * When 注文を登録する
+   * Then 注文コードと注文日時と初期ステータスが設定される
+   * </pre>
+   */
+  @Test
+  @DisplayName("注文を登録できること")
+  void shouldCreateOrder() {
+    OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
+    OrderedAt actualOrderedAt = OrderedAt.of(orderedAt);
+    OrderCode orderCode = OrderCode.of("ORD000001");
 
-        Order actual = Order.create(orderCode, actualOrderedAt);
+    Order actual = Order.create(orderCode, actualOrderedAt);
 
-        assertEquals("ORD000001", actual.getOrderCode().getValue());
-        assertEquals("2026-04-09T10:15:30+09:00", actual.getOrderedAt().getValue().toString());
-        assertEquals("001", actual.getOrderStatus().getCode());
-        assertEquals(0L, actual.getVersion().getValue());
-    }
+    assertEquals("ORD000001", actual.getOrderCode().getValue());
+    assertEquals("2026-04-09T10:15:30+09:00", actual.getOrderedAt().getValue().toString());
+    assertEquals("001", actual.getOrderStatus().getCode());
+    assertEquals(0L, actual.getVersion().getValue());
+  }
 
-    /**
-     * <pre>
-     * Given 受付状態の注文を用意する
-     * When 注文をキャンセルする
-     * Then 注文ステータスがキャンセルになる
-     * </pre>
-     */
-    @Test
-    @DisplayName("注文をキャンセルできること")
-    void shouldCancelOrder() {
-        OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
-        Order order = Order.reconstruct(
+  /**
+   *
+   *
+   * <pre>
+   * Given 受付状態の注文を用意する
+   * When 注文をキャンセルする
+   * Then 注文ステータスがキャンセルになる
+   * </pre>
+   */
+  @Test
+  @DisplayName("注文をキャンセルできること")
+  void shouldCancelOrder() {
+    OffsetDateTime orderedAt = OffsetDateTime.parse("2026-04-09T10:15:30+09:00");
+    Order order =
+        Order.reconstruct(
             OrderId.of(UUID.fromString("00000000-0000-0000-0000-000000000001")),
             OrderCode.of("ORD000001"),
             OrderedAt.of(orderedAt),
             OrderStatus.RECEIVED,
-            Version.of(3L)
-        );
+            Version.of(3L));
 
-        Order actual = order.cancel(Version.of(3L));
+    Order actual = order.cancel(Version.of(3L));
 
-        assertEquals("006", actual.getOrderStatus().getCode());
-        assertEquals("00000000-0000-0000-0000-000000000001", actual.getOrderId().getValue().toString());
-        assertEquals("ORD000001", actual.getOrderCode().getValue());
-        assertEquals("2026-04-09T10:15:30+09:00", actual.getOrderedAt().getValue().toString());
-        assertEquals(3L, actual.getVersion().getValue());
-    }
+    assertEquals("006", actual.getOrderStatus().getCode());
+    assertEquals("00000000-0000-0000-0000-000000000001", actual.getOrderId().getValue().toString());
+    assertEquals("ORD000001", actual.getOrderCode().getValue());
+    assertEquals("2026-04-09T10:15:30+09:00", actual.getOrderedAt().getValue().toString());
+    assertEquals(3L, actual.getVersion().getValue());
+  }
 
-    /**
-     * <pre>
-     * Given 完了状態の注文を用意する
-     * When 注文をキャンセルする
-     * Then 注文キャンセル不可例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("完了済み注文はキャンセルできないこと")
-    void shouldThrowExceptionWhenCompletedOrderIsCancelled() {
-        Order order = Order.reconstruct(
+  /**
+   *
+   *
+   * <pre>
+   * Given 完了状態の注文を用意する
+   * When 注文をキャンセルする
+   * Then 注文キャンセル不可例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("完了済み注文はキャンセルできないこと")
+  void shouldThrowExceptionWhenCompletedOrderIsCancelled() {
+    Order order =
+        Order.reconstruct(
             OrderId.of(UUID.fromString("00000000-0000-0000-0000-000000000002")),
             OrderCode.of("ORD000001"),
             OrderedAt.of(OffsetDateTime.parse("2026-04-09T10:15:30+09:00")),
             OrderStatus.COMPLETED,
-            Version.of(1L)
-        );
-        Version requestedVersion = Version.of(1L);
+            Version.of(1L));
+    Version requestedVersion = Version.of(1L);
 
-        OrderCannotBeCancelledException actual = assertThrows(
-            OrderCannotBeCancelledException.class,
-            () -> order.cancel(requestedVersion)
-        );
+    OrderCannotBeCancelledException actual =
+        assertThrows(OrderCannotBeCancelledException.class, () -> order.cancel(requestedVersion));
 
-        assertEquals(
-            "注文をキャンセルできません: orderId=00000000-0000-0000-0000-000000000002, orderCode=ORD000001, status=COMPLETED",
-            actual.getMessage()
-        );
-    }
+    assertEquals(
+        "注文をキャンセルできません: orderId=00000000-0000-0000-0000-000000000002, orderCode=ORD000001,"
+            + " status=COMPLETED",
+        actual.getMessage());
+  }
 
-    /**
-     * <pre>
-     * Given version が進んだ注文データを用意する
-     * When 不一致の version で注文をキャンセルする
-     * Then 注文の楽観ロック競合例外が発生する
-     * </pre>
-     */
-    @Test
-    @DisplayName("stale version でキャンセルすると競合例外になる")
-    void shouldThrowExceptionWhenVersionDoesNotMatch() {
-        Order order = Order.reconstruct(
+  /**
+   *
+   *
+   * <pre>
+   * Given version が進んだ注文データを用意する
+   * When 不一致の version で注文をキャンセルする
+   * Then 注文の楽観ロック競合例外が発生する
+   * </pre>
+   */
+  @Test
+  @DisplayName("stale version でキャンセルすると競合例外になる")
+  void shouldThrowExceptionWhenVersionDoesNotMatch() {
+    Order order =
+        Order.reconstruct(
             OrderId.of(UUID.fromString("00000000-0000-0000-0000-000000000003")),
             OrderCode.of("ORD000001"),
             OrderedAt.of(OffsetDateTime.parse("2026-04-09T10:15:30+09:00")),
             OrderStatus.RECEIVED,
-            Version.of(1L)
-        );
-        Version requestedVersion = Version.of(2L);
+            Version.of(1L));
+    Version requestedVersion = Version.of(2L);
 
-        OrderVersionConflictException actual = assertThrows(
-            OrderVersionConflictException.class,
-            () -> order.cancel(requestedVersion)
-        );
+    OrderVersionConflictException actual =
+        assertThrows(OrderVersionConflictException.class, () -> order.cancel(requestedVersion));
 
-        assertEquals(
-            "注文のバージョンが競合しています: orderId=00000000-0000-0000-0000-000000000003, orderCode=ORD000001, currentVersion=1, requestedVersion=2",
-            actual.getMessage()
-        );
-    }
+    assertEquals(
+        "注文のバージョンが競合しています: orderId=00000000-0000-0000-0000-000000000003, orderCode=ORD000001,"
+            + " currentVersion=1, requestedVersion=2",
+        actual.getMessage());
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/VersionTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/domain/order/VersionTest.java
@@ -1,47 +1,49 @@
 package jp.co.shimizutdev.phoneorderapi.domain.order;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-/**
- * バージョンテスト
- */
+/** バージョンテスト */
 class VersionTest {
 
-    /**
-     * <pre>
-     * Given 0以上のバージョン値を用意する
-     * When バージョンを生成する
-     * Then バージョンが生成される
-     * </pre>
-     */
-    @Test
-    @DisplayName("0以上のバージョンを生成できること")
-    void shouldCreateVersionWhenValueIsZeroOrGreater() {
-        Version actual = Version.of(1L);
+  /**
+   *
+   *
+   * <pre>
+   * Given 0以上のバージョン値を用意する
+   * When バージョンを生成する
+   * Then バージョンが生成される
+   * </pre>
+   */
+  @Test
+  @DisplayName("0以上のバージョンを生成できること")
+  void shouldCreateVersionWhenValueIsZeroOrGreater() {
+    Version actual = Version.of(1L);
 
-        assertEquals(1L, actual.getValue());
-    }
+    assertEquals(1L, actual.getValue());
+  }
 
-    /**
-     * <pre>
-     * Given 負のバージョン値を用意する
-     * When バージョンを生成する
-     * Then 例外が発生する
-     * </pre>
-     */
-    @ParameterizedTest
-    @ValueSource(longs = {-1L, -10L})
-    @DisplayName("負のバージョン値は例外になる")
-    void shouldThrowExceptionWhenVersionIsNegative(final long value) {
-        IllegalArgumentException actual =
-            assertThrows(IllegalArgumentException.class, () -> Version.of(value));
+  /**
+   *
+   *
+   * <pre>
+   * Given 負のバージョン値を用意する
+   * When バージョンを生成する
+   * Then 例外が発生する
+   * </pre>
+   */
+  @ParameterizedTest
+  @ValueSource(longs = {-1L, -10L})
+  @DisplayName("負のバージョン値は例外になる")
+  void shouldThrowExceptionWhenVersionIsNegative(final long value) {
+    IllegalArgumentException actual =
+        assertThrows(IllegalArgumentException.class, () -> Version.of(value));
 
-        assertEquals("バージョンは0以上である必要があります。", actual.getMessage());
-    }
+    assertEquals("バージョンは0以上である必要があります。", actual.getMessage());
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/LogMaskerTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/LogMaskerTest.java
@@ -1,120 +1,127 @@
 package jp.co.shimizutdev.phoneorderapi.infrastructure.log;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * デフォルトログマスキング実装テスト
- */
+/** デフォルトログマスキング実装テスト */
 class LogMaskerTest {
 
-    private final LogMasker logMasker = new LogMasker(new ObjectMapper());
+  private final LogMasker logMasker = new LogMasker(new ObjectMapper());
 
-    /**
-     * <pre>
-     * Given マスク対象ヘッダーを用意する
-     * When ヘッダー値をマスキングする
-     * Then ヘッダー値がマスク文字列へ変換される
-     * </pre>
-     */
-    @Test
-    @DisplayName("マスク対象ヘッダーはマスクされること")
-    void shouldMaskTargetHeader() {
-        String actual = logMasker.maskHeader("Authorization", "Bearer secret-token");
+  /**
+   *
+   *
+   * <pre>
+   * Given マスク対象ヘッダーを用意する
+   * When ヘッダー値をマスキングする
+   * Then ヘッダー値がマスク文字列へ変換される
+   * </pre>
+   */
+  @Test
+  @DisplayName("マスク対象ヘッダーはマスクされること")
+  void shouldMaskTargetHeader() {
+    String actual = logMasker.maskHeader("Authorization", "Bearer secret-token");
 
-        assertThat(actual).isEqualTo("****");
-    }
+    assertThat(actual).isEqualTo("****");
+  }
 
-    /**
-     * <pre>
-     * Given マスク対象外ヘッダーを用意する
-     * When ヘッダー値をマスキングする
-     * Then 元のヘッダー値がそのまま返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("マスク対象外ヘッダーはそのまま返すこと")
-    void shouldReturnOriginalValueWhenHeaderIsNotMaskTarget() {
-        String actual = logMasker.maskHeader("Content-Type", "application/json");
+  /**
+   *
+   *
+   * <pre>
+   * Given マスク対象外ヘッダーを用意する
+   * When ヘッダー値をマスキングする
+   * Then 元のヘッダー値がそのまま返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("マスク対象外ヘッダーはそのまま返すこと")
+  void shouldReturnOriginalValueWhenHeaderIsNotMaskTarget() {
+    String actual = logMasker.maskHeader("Content-Type", "application/json");
 
-        assertThat(actual).isEqualTo("application/json");
-    }
+    assertThat(actual).isEqualTo("application/json");
+  }
 
-    /**
-     * <pre>
-     * Given マスク対象項目を含むJSON文字列を用意する
-     * When テキストをマスキングする
-     * Then ネストした項目や配列要素も含めてマスクされる
-     * </pre>
-     */
-    @Test
-    @DisplayName("JSON文字列のマスク対象項目を再帰的にマスクできること")
-    void shouldMaskNestedJsonText() {
-        String text = """
+  /**
+   *
+   *
+   * <pre>
+   * Given マスク対象項目を含むJSON文字列を用意する
+   * When テキストをマスキングする
+   * Then ネストした項目や配列要素も含めてマスクされる
+   * </pre>
+   */
+  @Test
+  @DisplayName("JSON文字列のマスク対象項目を再帰的にマスクできること")
+  void shouldMaskNestedJsonText() {
+    String text =
+        """
+        {
+          "token": "secret-token",
+          "profile": {
+            "email": "taro@example.com",
+            "name": "taro"
+          },
+          "children": [
             {
-              "token": "secret-token",
-              "profile": {
-                "email": "taro@example.com",
-                "name": "taro"
-              },
-              "children": [
-                {
-                  "password": "secret-password"
-                }
-              ]
+              "password": "secret-password"
             }
-            """;
+          ]
+        }
+        """;
 
-        String actual = logMasker.maskText(text);
+    String actual = logMasker.maskText(text);
 
-        assertThat(actual).isEqualTo(
-            "{\"token\":\"****\",\"profile\":{\"email\":\"****\",\"name\":\"taro\"},\"children\":[{\"password\":\"****\"}]}"
-        );
-    }
+    assertThat(actual)
+        .isEqualTo(
+            "{\"token\":\"****\",\"profile\":{\"email\":\"****\",\"name\":\"taro\"},\"children\":[{\"password\":\"****\"}]}");
+  }
 
-    /**
-     * <pre>
-     * Given 改行を含む非JSON文字列を用意する
-     * When テキストをマスキングする
-     * Then 改行と連続空白が正規化された1行文字列になる
-     * </pre>
-     */
-    @Test
-    @DisplayName("JSONでない文字列は1行化されること")
-    void shouldNormalizeWhitespaceWhenTextIsNotJson() {
-        String text = "line1\n  line2\r\nline3";
+  /**
+   *
+   *
+   * <pre>
+   * Given 改行を含む非JSON文字列を用意する
+   * When テキストをマスキングする
+   * Then 改行と連続空白が正規化された1行文字列になる
+   * </pre>
+   */
+  @Test
+  @DisplayName("JSONでない文字列は1行化されること")
+  void shouldNormalizeWhitespaceWhenTextIsNotJson() {
+    String text = "line1\n  line2\r\nline3";
 
-        String actual = logMasker.maskText(text);
+    String actual = logMasker.maskText(text);
 
-        assertThat(actual).isEqualTo("line1 line2 line3");
-    }
+    assertThat(actual).isEqualTo("line1 line2 line3");
+  }
 
-    /**
-     * <pre>
-     * Given マスク対象項目を含むオブジェクトを用意する
-     * When オブジェクトをマスキングする
-     * Then マスク対象項目だけがマスク文字列へ変換される
-     * </pre>
-     */
-    @Test
-    @DisplayName("オブジェクトのマスク対象項目をマスクできること")
-    void shouldMaskObjectFields() {
-        Map<String, String> request = new LinkedHashMap<>();
-        request.put("orderedAt", "2026-04-07T10:15:30+09:00");
-        request.put("password", "secret-password");
-        request.put("email", "taro@example.com");
+  /**
+   *
+   *
+   * <pre>
+   * Given マスク対象項目を含むオブジェクトを用意する
+   * When オブジェクトをマスキングする
+   * Then マスク対象項目だけがマスク文字列へ変換される
+   * </pre>
+   */
+  @Test
+  @DisplayName("オブジェクトのマスク対象項目をマスクできること")
+  void shouldMaskObjectFields() {
+    Map<String, String> request = new LinkedHashMap<>();
+    request.put("orderedAt", "2026-04-07T10:15:30+09:00");
+    request.put("password", "secret-password");
+    request.put("email", "taro@example.com");
 
-        String actual = logMasker.maskObject(request);
+    String actual = logMasker.maskObject(request);
 
-        assertThat(actual).isEqualTo(
-            "{\"orderedAt\":\"2026-04-07T10:15:30+09:00\",\"password\":\"****\",\"email\":\"****\"}"
-        );
-    }
-
+    assertThat(actual)
+        .isEqualTo(
+            "{\"orderedAt\":\"2026-04-07T10:15:30+09:00\",\"password\":\"****\",\"email\":\"****\"}");
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/infrastructure/log/MethodLogAspectTest.java
@@ -1,5 +1,7 @@
 package jp.co.shimizutdev.phoneorderapi.infrastructure.log;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import jp.co.shimizutdev.phoneorderapi.application.order.OrderService;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PagingCondition;
 import jp.co.shimizutdev.phoneorderapi.support.AbstractPostgreSQLTest;
@@ -16,69 +18,67 @@ import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 import org.springframework.test.context.jdbc.SqlMergeMode.MergeMode;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/**
- * メソッド開始/終了ログ出力アスペクトテスト
- */
-@SpringBootTest(properties = "logging.level.jp.co.shimizutdev.phoneorderapi.infrastructure.log.MethodLogAspect=DEBUG")
+/** メソッド開始/終了ログ出力アスペクトテスト */
+@SpringBootTest(
+    properties =
+        "logging.level.jp.co.shimizutdev.phoneorderapi.infrastructure.log.MethodLogAspect=DEBUG")
 @ExtendWith(OutputCaptureExtension.class)
 @ResetLogLevel(MethodLogAspect.class)
 @SqlMergeMode(MergeMode.MERGE)
 @Sql(
     scripts = "classpath:sql/cleanup/cleanup-transaction-tables.sql",
-    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD
-)
+    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(
     scripts = "classpath:sql/cleanup/cleanup-transaction-tables.sql",
-    executionPhase = ExecutionPhase.AFTER_TEST_METHOD
-)
+    executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
 class MethodLogAspectTest extends AbstractPostgreSQLTest {
 
-    /**
-     * 注文サービス
-     */
-    @Autowired
-    private OrderService orderService;
+  /** 注文サービス */
+  @Autowired private OrderService orderService;
 
-    /**
-     * <pre>
-     * Given 注文データが複数件登録されている
-     * When 注文一覧取得メソッドを実行する
-     * Then 開始終了ログ、戻り値型、注文コードが出力される
-     * </pre>
-     */
-    @Test
-    @DisplayName("メソッド開始終了ログに戻り値型と注文コードが出力されること")
-    @Sql(statements = {
-        "insert into orders (id, order_code, ordered_at, order_status, created_by, updated_by) values "
-            + "('11111111-1111-1111-1111-111111111111', 'ORD000001', '2026-04-09T10:00:00+09:00', '001', 'system', 'system')",
-        "insert into orders (id, order_code, ordered_at, order_status, created_by, updated_by) values "
-            + "('22222222-2222-2222-2222-222222222222', 'ORD000002', '2026-04-09T11:00:00+09:00', '002', 'system', 'system')"
-    })
-    void shouldLogMethodStartEndReturnTypeAndOrderCodes(final CapturedOutput output) {
-        orderService.getOrders(PagingCondition.of(0, 20));
+  /**
+   *
+   *
+   * <pre>
+   * Given 注文データが複数件登録されている
+   * When 注文一覧取得メソッドを実行する
+   * Then 開始終了ログ、戻り値型、注文コードが出力される
+   * </pre>
+   */
+  @Test
+  @DisplayName("メソッド開始終了ログに戻り値型と注文コードが出力されること")
+  @Sql(
+      statements = {
+        "insert into orders (id, order_code, ordered_at, order_status, created_by, updated_by)"
+            + " values ('11111111-1111-1111-1111-111111111111', 'ORD000001',"
+            + " '2026-04-09T10:00:00+09:00', '001', 'system', 'system')",
+        "insert into orders (id, order_code, ordered_at, order_status, created_by, updated_by)"
+            + " values ('22222222-2222-2222-2222-222222222222', 'ORD000002',"
+            + " '2026-04-09T11:00:00+09:00', '002', 'system', 'system')"
+      })
+  void shouldLogMethodStartEndReturnTypeAndOrderCodes(final CapturedOutput output) {
+    orderService.getOrders(PagingCondition.of(0, 20));
 
-        assertThat(output)
-            .contains("[method start] methodName: OrderService#getOrders")
-            .contains("[method start] arguments: [Object[]] [{\"page\":0,\"size\":20}]")
-            .contains("[method end] methodName: OrderService#getOrders")
-            .contains("[method end] duration(ms):")
-            .contains("[method end] return value: [PageResult<Order>]")
-            .contains("\"items\":[")
-            .contains("\"orderId\":{\"value\":\"22222222-2222-2222-2222-222222222222\"}")
-            .contains("\"orderCode\":{\"value\":\"ORD000002\"}")
-            .contains("\"orderedAt\":{\"value\":\"2026-04-09T02:00:00Z\"}")
-            .contains("\"orderStatus\":\"UNDER_REVIEW\"")
-            .contains("\"version\":{\"value\":0}")
-            .contains("\"orderId\":{\"value\":\"11111111-1111-1111-1111-111111111111\"}")
-            .contains("\"orderCode\":{\"value\":\"ORD000001\"}")
-            .contains("\"orderedAt\":{\"value\":\"2026-04-09T01:00:00Z\"}")
-            .contains("\"orderStatus\":\"RECEIVED\"")
-            .contains("\"version\":{\"value\":0}")
-            .contains("\"page\":0")
-            .contains("\"size\":20")
-            .contains("\"totalElements\":2")
-            .contains("\"totalPages\":1");
-    }
+    assertThat(output)
+        .contains("[method start] methodName: OrderService#getOrders")
+        .contains("[method start] arguments: [Object[]] [{\"page\":0,\"size\":20}]")
+        .contains("[method end] methodName: OrderService#getOrders")
+        .contains("[method end] duration(ms):")
+        .contains("[method end] return value: [PageResult<Order>]")
+        .contains("\"items\":[")
+        .contains("\"orderId\":{\"value\":\"22222222-2222-2222-2222-222222222222\"}")
+        .contains("\"orderCode\":{\"value\":\"ORD000002\"}")
+        .contains("\"orderedAt\":{\"value\":\"2026-04-09T02:00:00Z\"}")
+        .contains("\"orderStatus\":\"UNDER_REVIEW\"")
+        .contains("\"version\":{\"value\":0}")
+        .contains("\"orderId\":{\"value\":\"11111111-1111-1111-1111-111111111111\"}")
+        .contains("\"orderCode\":{\"value\":\"ORD000001\"}")
+        .contains("\"orderedAt\":{\"value\":\"2026-04-09T01:00:00Z\"}")
+        .contains("\"orderStatus\":\"RECEIVED\"")
+        .contains("\"version\":{\"value\":0}")
+        .contains("\"page\":0")
+        .contains("\"size\":20")
+        .contains("\"totalElements\":2")
+        .contains("\"totalPages\":1");
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandlerTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/error/ApiExceptionHandlerTest.java
@@ -1,9 +1,19 @@
 package jp.co.shimizutdev.phoneorderapi.presentation.error;
 
+import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import java.util.UUID;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.config.InvalidAuditorException;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.InvalidPersistedOrderException;
 import jp.co.shimizutdev.phoneorderapi.infrastructure.persistence.order.OrderJpaEntity;
@@ -17,212 +27,210 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
-
-import static com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS;
-import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-/**
- * API例外ハンドラテスト
- */
+/** API例外ハンドラテスト */
 class ApiExceptionHandlerTest {
 
-    /**
-     * MockMvc
-     */
-    private MockMvc mockMvc;
+  /** MockMvc */
+  private MockMvc mockMvc;
 
-    /**
-     * テスト前処理
-     */
-    @BeforeEach
-    void setUp() {
-        ObjectMapper objectMapper = new ObjectMapper()
-            .registerModule(new JavaTimeModule())
-            .disable(WRITE_DATES_AS_TIMESTAMPS);
+  /** テスト前処理 */
+  @BeforeEach
+  void setUp() {
+    ObjectMapper objectMapper =
+        new ObjectMapper().registerModule(new JavaTimeModule()).disable(WRITE_DATES_AS_TIMESTAMPS);
 
-        LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
-        validator.afterPropertiesSet();
+    LocalValidatorFactoryBean validator = new LocalValidatorFactoryBean();
+    validator.afterPropertiesSet();
 
-        mockMvc = MockMvcBuilders
-            .standaloneSetup(new TestController())
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(new TestController())
             .setControllerAdvice(new ApiExceptionHandler())
             .setMessageConverters(new MappingJackson2HttpMessageConverter(objectMapper))
             .setValidator(validator)
             .build();
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given IllegalArgumentExceptionを送出するAPIがある
+   * When IllegalArgumentException発生APIを実行する
+   * Then 400 Bad Requestのエラーレスポンスが返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("IllegalArgumentExceptionは400に変換されること")
+  void shouldReturnBadRequestWhenIllegalArgumentExceptionOccurs() throws Exception {
+    mockMvc
+        .perform(get("/test/errors/illegal-argument"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.timestamp").isString())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
+        .andExpect(jsonPath("$.path").value("/test/errors/illegal-argument"))
+        .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given メッセージなしIllegalArgumentExceptionを送出するAPIがある
+   * When メッセージなしIllegalArgumentException発生APIを実行する
+   * Then 400 Bad Requestとバリデーションエラーメッセージのエラーレスポンスが返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("メッセージなしIllegalArgumentExceptionはバリデーションエラーメッセージで400に変換されること")
+  void shouldReturnValidationErrorMessageWhenIllegalArgumentExceptionHasNoMessage()
+      throws Exception {
+    mockMvc
+        .perform(get("/test/errors/illegal-argument-without-message"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.timestamp").isString())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
+        .andExpect(jsonPath("$.path").value("/test/errors/illegal-argument-without-message"))
+        .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given バリデーションエラーとなるリクエストを受け付けるAPIがある
+   * When 必須項目不足のリクエストでAPIを実行する
+   * Then 400 Bad Requestとバリデーションエラー詳細が返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("バリデーションエラーは400に変換されること")
+  void shouldReturnBadRequestWhenValidationErrorOccurs() throws Exception {
+    mockMvc
+        .perform(
+            post("/test/errors/validation").contentType(MediaType.APPLICATION_JSON).content("{}"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.timestamp").isString())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
+        .andExpect(jsonPath("$.path").value("/test/errors/validation"))
+        .andExpect(jsonPath("$.validationErrors", hasSize(1)))
+        .andExpect(jsonPath("$.validationErrors[0].field").value("name"))
+        .andExpect(jsonPath("$.validationErrors[0].message").value("name is required."));
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given 監査ユーザー不正例外を送出するAPIがある
+   * When 監査ユーザー不正例外発生APIを実行する
+   * Then 400 Bad Requestのエラーレスポンスが返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("監査ユーザー不正例外は400に変換されること")
+  void shouldReturnBadRequestWhenInvalidAuditorExceptionOccurs() throws Exception {
+    mockMvc
+        .perform(get("/test/errors/invalid-auditor"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.timestamp").isString())
+        .andExpect(jsonPath("$.status").value(400))
+        .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+        .andExpect(jsonPath("$.message").value(ApiErrorMessages.INVALID_AUDITOR))
+        .andExpect(jsonPath("$.path").value("/test/errors/invalid-auditor"))
+        .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given 想定外例外を送出するAPIがある
+   * When 想定外例外発生APIを実行する
+   * Then 500 Internal Server Errorと汎用エラーメッセージが返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("想定外例外は汎用メッセージの500に変換されること")
+  void shouldReturnInternalServerErrorWhenUnexpectedExceptionOccurs() throws Exception {
+    mockMvc
+        .perform(get("/test/errors/unexpected"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.timestamp").isString())
+        .andExpect(jsonPath("$.status").value(500))
+        .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
+        .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
+        .andExpect(jsonPath("$.path").value("/test/errors/unexpected"))
+        .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given 永続化済み注文データ不整合例外を送出するAPIがある
+   * When 永続化済み注文データ不整合例外発生APIを実行する
+   * Then 500 Internal Server Errorのエラーレスポンスが返る
+   * </pre>
+   */
+  @Test
+  @DisplayName("永続化済み注文データ不整合例外は500に変換されること")
+  void shouldReturnInternalServerErrorWhenInvalidPersistedOrderExceptionOccurs() throws Exception {
+    mockMvc
+        .perform(get("/test/errors/invalid-persisted-order"))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.timestamp").isString())
+        .andExpect(jsonPath("$.status").value(500))
+        .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
+        .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
+        .andExpect(jsonPath("$.path").value("/test/errors/invalid-persisted-order"))
+        .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+  }
+
+  @RestController
+  @RequestMapping("/test/errors")
+  static class TestController {
+
+    @GetMapping("/illegal-argument")
+    String throwIllegalArgumentException() {
+      throw new IllegalArgumentException("illegal argument occurred");
     }
 
-    /**
-     * <pre>
-     * Given IllegalArgumentExceptionを送出するAPIがある
-     * When IllegalArgumentException発生APIを実行する
-     * Then 400 Bad Requestのエラーレスポンスが返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("IllegalArgumentExceptionは400に変換されること")
-    void shouldReturnBadRequestWhenIllegalArgumentExceptionOccurs() throws Exception {
-        mockMvc.perform(get("/test/errors/illegal-argument"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.timestamp").isString())
-            .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-            .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
-            .andExpect(jsonPath("$.path").value("/test/errors/illegal-argument"))
-            .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    @GetMapping("/illegal-argument-without-message")
+    String throwIllegalArgumentExceptionWithoutMessage() {
+      throw new IllegalArgumentException();
     }
 
-    /**
-     * <pre>
-     * Given メッセージなしIllegalArgumentExceptionを送出するAPIがある
-     * When メッセージなしIllegalArgumentException発生APIを実行する
-     * Then 400 Bad Requestとバリデーションエラーメッセージのエラーレスポンスが返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("メッセージなしIllegalArgumentExceptionはバリデーションエラーメッセージで400に変換されること")
-    void shouldReturnValidationErrorMessageWhenIllegalArgumentExceptionHasNoMessage() throws Exception {
-        mockMvc.perform(get("/test/errors/illegal-argument-without-message"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.timestamp").isString())
-            .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-            .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
-            .andExpect(jsonPath("$.path").value("/test/errors/illegal-argument-without-message"))
-            .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    @PostMapping("/validation")
+    String validate(@Valid @RequestBody final TestRequest request) {
+      return request.name();
     }
 
-    /**
-     * <pre>
-     * Given バリデーションエラーとなるリクエストを受け付けるAPIがある
-     * When 必須項目不足のリクエストでAPIを実行する
-     * Then 400 Bad Requestとバリデーションエラー詳細が返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("バリデーションエラーは400に変換されること")
-    void shouldReturnBadRequestWhenValidationErrorOccurs() throws Exception {
-        mockMvc.perform(post("/test/errors/validation")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("{}"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.timestamp").isString())
-            .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-            .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
-            .andExpect(jsonPath("$.path").value("/test/errors/validation"))
-            .andExpect(jsonPath("$.validationErrors", hasSize(1)))
-            .andExpect(jsonPath("$.validationErrors[0].field").value("name"))
-            .andExpect(jsonPath("$.validationErrors[0].message").value("name is required."));
+    @GetMapping("/invalid-auditor")
+    String throwInvalidAuditorException() {
+      throw new InvalidAuditorException(ApiErrorMessages.INVALID_AUDITOR);
     }
 
-    /**
-     * <pre>
-     * Given 監査ユーザー不正例外を送出するAPIがある
-     * When 監査ユーザー不正例外発生APIを実行する
-     * Then 400 Bad Requestのエラーレスポンスが返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("監査ユーザー不正例外は400に変換されること")
-    void shouldReturnBadRequestWhenInvalidAuditorExceptionOccurs() throws Exception {
-        mockMvc.perform(get("/test/errors/invalid-auditor"))
-            .andExpect(status().isBadRequest())
-            .andExpect(jsonPath("$.timestamp").isString())
-            .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-            .andExpect(jsonPath("$.message").value(ApiErrorMessages.INVALID_AUDITOR))
-            .andExpect(jsonPath("$.path").value("/test/errors/invalid-auditor"))
-            .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    @GetMapping("/unexpected")
+    String throwUnexpectedException() {
+      throw new IllegalStateException("boom");
     }
 
-    /**
-     * <pre>
-     * Given 想定外例外を送出するAPIがある
-     * When 想定外例外発生APIを実行する
-     * Then 500 Internal Server Errorと汎用エラーメッセージが返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("想定外例外は汎用メッセージの500に変換されること")
-    void shouldReturnInternalServerErrorWhenUnexpectedExceptionOccurs() throws Exception {
-        mockMvc.perform(get("/test/errors/unexpected"))
-            .andExpect(status().isInternalServerError())
-            .andExpect(jsonPath("$.timestamp").isString())
-            .andExpect(jsonPath("$.status").value(500))
-            .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
-            .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
-            .andExpect(jsonPath("$.path").value("/test/errors/unexpected"))
-            .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    @GetMapping("/invalid-persisted-order")
+    String throwInvalidPersistedOrderException() {
+      OrderJpaEntity orderJpaEntity = mock(OrderJpaEntity.class);
+      when(orderJpaEntity.getId())
+          .thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000001"));
+      when(orderJpaEntity.getOrderCode()).thenReturn("ORD000001");
+      throw InvalidPersistedOrderException.byOrderJpaEntity(
+          "persisted order is invalid", orderJpaEntity);
     }
+  }
 
-    /**
-     * <pre>
-     * Given 永続化済み注文データ不整合例外を送出するAPIがある
-     * When 永続化済み注文データ不整合例外発生APIを実行する
-     * Then 500 Internal Server Errorのエラーレスポンスが返る
-     * </pre>
-     */
-    @Test
-    @DisplayName("永続化済み注文データ不整合例外は500に変換されること")
-    void shouldReturnInternalServerErrorWhenInvalidPersistedOrderExceptionOccurs() throws Exception {
-        mockMvc.perform(get("/test/errors/invalid-persisted-order"))
-            .andExpect(status().isInternalServerError())
-            .andExpect(jsonPath("$.timestamp").isString())
-            .andExpect(jsonPath("$.status").value(500))
-            .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
-            .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
-            .andExpect(jsonPath("$.path").value("/test/errors/invalid-persisted-order"))
-            .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-    }
-
-    @RestController
-    @RequestMapping("/test/errors")
-    static class TestController {
-
-        @GetMapping("/illegal-argument")
-        String throwIllegalArgumentException() {
-            throw new IllegalArgumentException("illegal argument occurred");
-        }
-
-        @GetMapping("/illegal-argument-without-message")
-        String throwIllegalArgumentExceptionWithoutMessage() {
-            throw new IllegalArgumentException();
-        }
-
-        @PostMapping("/validation")
-        String validate(@Valid @RequestBody final TestRequest request) {
-            return request.name();
-        }
-
-        @GetMapping("/invalid-auditor")
-        String throwInvalidAuditorException() {
-            throw new InvalidAuditorException(ApiErrorMessages.INVALID_AUDITOR);
-        }
-
-        @GetMapping("/unexpected")
-        String throwUnexpectedException() {
-            throw new IllegalStateException("boom");
-        }
-
-        @GetMapping("/invalid-persisted-order")
-        String throwInvalidPersistedOrderException() {
-            OrderJpaEntity orderJpaEntity = mock(OrderJpaEntity.class);
-            when(orderJpaEntity.getId()).thenReturn(UUID.fromString("00000000-0000-0000-0000-000000000001"));
-            when(orderJpaEntity.getOrderCode()).thenReturn("ORD000001");
-            throw InvalidPersistedOrderException.byOrderJpaEntity("persisted order is invalid", orderJpaEntity);
-        }
-    }
-
-    private record TestRequest(
-        @NotBlank(message = "name is required.")
-        String name
-    ) {
-    }
+  private record TestRequest(@NotBlank(message = "name is required.") String name) {}
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/RequestResponseLogFilterTest.java
@@ -1,5 +1,11 @@
 package jp.co.shimizutdev.phoneorderapi.presentation.log;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletResponse;
@@ -20,107 +26,109 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-/**
- * リクエスト/レスポンスのログを出力するフィルタテスト
- */
-@SpringBootTest(properties = "logging.level.jp.co.shimizutdev.phoneorderapi.presentation.log.RequestResponseLogFilter=DEBUG")
+/** リクエスト/レスポンスのログを出力するフィルタテスト */
+@SpringBootTest(
+    properties =
+        "logging.level.jp.co.shimizutdev.phoneorderapi.presentation.log.RequestResponseLogFilter=DEBUG")
 @AutoConfigureMockMvc
 @ExtendWith(OutputCaptureExtension.class)
 @ResetLogLevel(RequestResponseLogFilter.class)
 class RequestResponseLogFilterTest extends AbstractPostgreSQLTest {
 
-    /**
-     * MockMvc
-     */
-    @Autowired
-    private MockMvc mockMvc;
+  /** MockMvc */
+  @Autowired private MockMvc mockMvc;
 
-    /**
-     * <pre>
-     * Given マスク対象ヘッダーとマスク対象項目を含むリクエストを用意する
-     * When 注文登録APIを実行する
-     * Then ログ出力時にヘッダーとボディ項目がマスクされる
-     * </pre>
-     */
-    @Test
-    @DisplayName("マスク対象ヘッダーとボディ項目がログでマスクされること")
-    void shouldMaskHeaderAndBodyInLogs(final CapturedOutput output) throws Exception {
-        mockMvc.perform(post("/api/v1/orders")
+  /**
+   *
+   *
+   * <pre>
+   * Given マスク対象ヘッダーとマスク対象項目を含むリクエストを用意する
+   * When 注文登録APIを実行する
+   * Then ログ出力時にヘッダーとボディ項目がマスクされる
+   * </pre>
+   */
+  @Test
+  @DisplayName("マスク対象ヘッダーとボディ項目がログでマスクされること")
+  void shouldMaskHeaderAndBodyInLogs(final CapturedOutput output) throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/orders")
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(HttpHeaders.AUTHORIZATION, "Bearer secret-token")
                 .header("X-Request-Id", "request-123")
                 .header("X-Forwarded-For", "203.0.113.10, 203.0.113.11")
-                .content("""
+                .content(
+                    """
                     {
                       "orderedAt": "invalid-date-time",
                       "password": "secret-password"
                     }
                     """))
-            .andExpect(status().isBadRequest());
+        .andExpect(status().isBadRequest());
 
-        assertThat(output)
-            .contains("[request] http method: POST")
-            .contains("[request] request uri: /api/v1/orders")
-            .contains("[request] content-type: application/json")
-            .contains("[request] client ip: 203.0.113.10")
-            .contains("[request] request id: request-123")
-            .contains("[request] query string:")
-            .contains("[request] parameters:")
-            .contains("Authorization=****")
-            .contains("X-Request-Id=request-123")
-            .contains("X-Forwarded-For=203.0.113.10, 203.0.113.11")
-            .contains("[request] body:")
-            .contains("\"orderedAt\":\"invalid-date-time\"")
-            .contains("\"password\":\"****\"")
-            .contains("[response] status: 400")
-            .contains("[response] content-type: application/json")
-            .contains("[response] duration(ms):")
-            .contains("[response] headers:")
-            .contains("[response] body:")
-            .contains("\"status\":400")
-            .contains("\"error\":\"BAD_REQUEST\"")
-            .contains("\"message\":\"リクエストボディの形式が不正です。\"")
-            .contains("\"path\":\"/api/v1/orders\"")
-            .contains("\"validationErrors\":[]")
-            .contains("[response] size(bytes):");
-    }
+    assertThat(output)
+        .contains("[request] http method: POST")
+        .contains("[request] request uri: /api/v1/orders")
+        .contains("[request] content-type: application/json")
+        .contains("[request] client ip: 203.0.113.10")
+        .contains("[request] request id: request-123")
+        .contains("[request] query string:")
+        .contains("[request] parameters:")
+        .contains("Authorization=****")
+        .contains("X-Request-Id=request-123")
+        .contains("X-Forwarded-For=203.0.113.10, 203.0.113.11")
+        .contains("[request] body:")
+        .contains("\"orderedAt\":\"invalid-date-time\"")
+        .contains("\"password\":\"****\"")
+        .contains("[response] status: 400")
+        .contains("[response] content-type: application/json")
+        .contains("[response] duration(ms):")
+        .contains("[response] headers:")
+        .contains("[response] body:")
+        .contains("\"status\":400")
+        .contains("\"error\":\"BAD_REQUEST\"")
+        .contains("\"message\":\"リクエストボディの形式が不正です。\"")
+        .contains("\"path\":\"/api/v1/orders\"")
+        .contains("\"validationErrors\":[]")
+        .contains("[response] size(bytes):");
+  }
 
-    /**
-     * <pre>
-     * Given 不正な文字エンコーディングを持つJSONリクエストを用意する
-     * When リクエスト/レスポンスログフィルタを実行する
-     * Then UTF-8へフォールバックしてレスポンスが返却される
-     * </pre>
-     */
-    @Test
-    @DisplayName("不正な文字エンコーディングでもUTF-8へフォールバックできること")
-    void shouldFallbackToUtf8WhenRequestEncodingIsInvalid() throws Exception {
-        RequestResponseLogFilter filter = new RequestResponseLogFilter(new LogMasker(new ObjectMapper()));
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        request.setMethod("POST");
-        request.setRequestURI("/test");
-        request.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        request.setCharacterEncoding("invalid-charset");
-        request.setContent("""
-            {"password":"secret-password"}
-            """.getBytes());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+  /**
+   *
+   *
+   * <pre>
+   * Given 不正な文字エンコーディングを持つJSONリクエストを用意する
+   * When リクエスト/レスポンスログフィルタを実行する
+   * Then UTF-8へフォールバックしてレスポンスが返却される
+   * </pre>
+   */
+  @Test
+  @DisplayName("不正な文字エンコーディングでもUTF-8へフォールバックできること")
+  void shouldFallbackToUtf8WhenRequestEncodingIsInvalid() throws Exception {
+    RequestResponseLogFilter filter =
+        new RequestResponseLogFilter(new LogMasker(new ObjectMapper()));
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.setMethod("POST");
+    request.setRequestURI("/test");
+    request.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    request.setCharacterEncoding("invalid-charset");
+    request.setContent(
+        """
+        {"password":"secret-password"}
+        """
+            .getBytes());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
-        FilterChain filterChain = (req, res) -> {
-            HttpServletResponse actualResponse = (HttpServletResponse) res;
-            actualResponse.setStatus(200);
-            actualResponse.getWriter().write("{\"status\":\"ok\"}");
+    FilterChain filterChain =
+        (req, res) -> {
+          HttpServletResponse actualResponse = (HttpServletResponse) res;
+          actualResponse.setStatus(200);
+          actualResponse.getWriter().write("{\"status\":\"ok\"}");
         };
 
-        assertDoesNotThrow(() -> filter.doFilter(request, response, filterChain));
-        assertEquals(200, response.getStatus());
-        assertThat(response.getContentAsString()).contains("\"status\":\"ok\"");
-    }
+    assertDoesNotThrow(() -> filter.doFilter(request, response, filterChain));
+    assertEquals(200, response.getStatus());
+    assertThat(response.getContentAsString()).contains("\"status\":\"ok\"");
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilterTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/log/TraceIdFilterTest.java
@@ -1,6 +1,10 @@
 package jp.co.shimizutdev.phoneorderapi.presentation.log;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import jakarta.servlet.FilterChain;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -8,154 +12,154 @@ import org.slf4j.MDC;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicReference;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-/**
- * トレースIDをMDCへ設定するFilterテスト
- */
+/** トレースIDをMDCへ設定するFilterテスト */
 class TraceIdFilterTest {
 
-    /**
-     * テスト後処理
-     */
-    @AfterEach
-    void tearDown() {
-        MDC.clear();
+  /** テスト後処理 */
+  @AfterEach
+  void tearDown() {
+    MDC.clear();
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given トレースIDフィルタを用意する
+   * When フィルタを実行する
+   * Then フィルタチェーン実行中にMDCへUUID形式のトレースIDが設定される
+   * </pre>
+   */
+  @Test
+  @DisplayName("フィルタチェーン実行中にトレースIDが設定されること")
+  void shouldSetTraceIdWhileFilterChainIsRunning() {
+    TraceIdFilter traceIdFilter = new TraceIdFilter();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    AtomicReference<String> actualTraceId = new AtomicReference<>();
+    FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
+
+    assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
+
+    assertTrue(isUuid(actualTraceId.get()));
+    assertEquals(actualTraceId.get(), response.getHeader("X-Trace-Id"));
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given X-Request-Id ヘッダーを含むリクエストを用意する
+   * When フィルタを実行する
+   * Then MDC とレスポンスヘッダーに同じ traceId が設定される
+   * </pre>
+   */
+  @Test
+  @DisplayName("X-Request-Id を traceId として引き継ぐこと")
+  void shouldReuseRequestIdHeaderAsTraceId() {
+    TraceIdFilter traceIdFilter = new TraceIdFilter();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.addHeader("X-Request-Id", "request-123");
+    AtomicReference<String> actualTraceId = new AtomicReference<>();
+    FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
+
+    assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
+
+    assertEquals("request-123", actualTraceId.get());
+    assertEquals("request-123", response.getHeader("X-Trace-Id"));
+    assertNull(MDC.get(TraceIdFilter.TRACE_ID_KEY));
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given 不正な X-Request-Id と有効な X-Correlation-Id を含むリクエストを用意する
+   * When フィルタを実行する
+   * Then X-Correlation-Id が traceId として設定される
+   * </pre>
+   */
+  @Test
+  @DisplayName("不正な X-Request-Id の場合は X-Correlation-Id を traceId として引き継ぐこと")
+  void shouldFallbackToCorrelationIdWhenRequestIdIsInvalid() {
+    TraceIdFilter traceIdFilter = new TraceIdFilter();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.addHeader("X-Request-Id", "invalid trace id");
+    request.addHeader("X-Correlation-Id", "correlation-123");
+    AtomicReference<String> actualTraceId = new AtomicReference<>();
+    FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
+
+    assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
+
+    assertEquals("correlation-123", actualTraceId.get());
+    assertEquals("correlation-123", response.getHeader("X-Trace-Id"));
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given 不正な X-Request-Id を含むリクエストを用意する
+   * When フィルタを実行する
+   * Then UUID形式の traceId が新規生成される
+   * </pre>
+   */
+  @Test
+  @DisplayName("不正なヘッダーの場合はUUID形式の traceId を生成すること")
+  void shouldGenerateTraceIdWhenHeadersAreInvalid() {
+    TraceIdFilter traceIdFilter = new TraceIdFilter();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    request.addHeader("X-Request-Id", "a".repeat(129));
+    AtomicReference<String> actualTraceId = new AtomicReference<>();
+    FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
+
+    assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
+
+    assertTrue(isUuid(actualTraceId.get()));
+    assertEquals(actualTraceId.get(), response.getHeader("X-Trace-Id"));
+  }
+
+  /**
+   *
+   *
+   * <pre>
+   * Given トレースIDフィルタを用意する
+   * When フィルタを実行する
+   * Then フィルタチェーン実行後にMDCからトレースIDが削除される
+   * </pre>
+   */
+  @Test
+  @DisplayName("フィルタチェーン実行後にトレースIDが削除されること")
+  void shouldRemoveTraceIdAfterFilterChainIsFinished() {
+    TraceIdFilter traceIdFilter = new TraceIdFilter();
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain filterChain = (req, res) -> {};
+
+    assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
+
+    assertNull(MDC.get(TraceIdFilter.TRACE_ID_KEY));
+  }
+
+  /**
+   * UUID形式かどうかを判定する
+   *
+   * @param value UUID形式判定対象文字列
+   * @return UUID形式の場合 true
+   */
+  private boolean isUuid(final String value) {
+    if (value == null) {
+      return false;
     }
 
-    /**
-     * <pre>
-     * Given トレースIDフィルタを用意する
-     * When フィルタを実行する
-     * Then フィルタチェーン実行中にMDCへUUID形式のトレースIDが設定される
-     * </pre>
-     */
-    @Test
-    @DisplayName("フィルタチェーン実行中にトレースIDが設定されること")
-    void shouldSetTraceIdWhileFilterChainIsRunning() {
-        TraceIdFilter traceIdFilter = new TraceIdFilter();
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        AtomicReference<String> actualTraceId = new AtomicReference<>();
-        FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
-
-        assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
-
-        assertTrue(isUuid(actualTraceId.get()));
-        assertEquals(actualTraceId.get(), response.getHeader("X-Trace-Id"));
+    try {
+      UUID.fromString(value);
+      return true;
+    } catch (IllegalArgumentException ex) {
+      return false;
     }
-
-    /**
-     * <pre>
-     * Given X-Request-Id ヘッダーを含むリクエストを用意する
-     * When フィルタを実行する
-     * Then MDC とレスポンスヘッダーに同じ traceId が設定される
-     * </pre>
-     */
-    @Test
-    @DisplayName("X-Request-Id を traceId として引き継ぐこと")
-    void shouldReuseRequestIdHeaderAsTraceId() {
-        TraceIdFilter traceIdFilter = new TraceIdFilter();
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        request.addHeader("X-Request-Id", "request-123");
-        AtomicReference<String> actualTraceId = new AtomicReference<>();
-        FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
-
-        assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
-
-        assertEquals("request-123", actualTraceId.get());
-        assertEquals("request-123", response.getHeader("X-Trace-Id"));
-        assertNull(MDC.get(TraceIdFilter.TRACE_ID_KEY));
-    }
-
-    /**
-     * <pre>
-     * Given 不正な X-Request-Id と有効な X-Correlation-Id を含むリクエストを用意する
-     * When フィルタを実行する
-     * Then X-Correlation-Id が traceId として設定される
-     * </pre>
-     */
-    @Test
-    @DisplayName("不正な X-Request-Id の場合は X-Correlation-Id を traceId として引き継ぐこと")
-    void shouldFallbackToCorrelationIdWhenRequestIdIsInvalid() {
-        TraceIdFilter traceIdFilter = new TraceIdFilter();
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        request.addHeader("X-Request-Id", "invalid trace id");
-        request.addHeader("X-Correlation-Id", "correlation-123");
-        AtomicReference<String> actualTraceId = new AtomicReference<>();
-        FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
-
-        assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
-
-        assertEquals("correlation-123", actualTraceId.get());
-        assertEquals("correlation-123", response.getHeader("X-Trace-Id"));
-    }
-
-    /**
-     * <pre>
-     * Given 不正な X-Request-Id を含むリクエストを用意する
-     * When フィルタを実行する
-     * Then UUID形式の traceId が新規生成される
-     * </pre>
-     */
-    @Test
-    @DisplayName("不正なヘッダーの場合はUUID形式の traceId を生成すること")
-    void shouldGenerateTraceIdWhenHeadersAreInvalid() {
-        TraceIdFilter traceIdFilter = new TraceIdFilter();
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        request.addHeader("X-Request-Id", "a".repeat(129));
-        AtomicReference<String> actualTraceId = new AtomicReference<>();
-        FilterChain filterChain = (req, res) -> actualTraceId.set(MDC.get(TraceIdFilter.TRACE_ID_KEY));
-
-        assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
-
-        assertTrue(isUuid(actualTraceId.get()));
-        assertEquals(actualTraceId.get(), response.getHeader("X-Trace-Id"));
-    }
-
-    /**
-     * <pre>
-     * Given トレースIDフィルタを用意する
-     * When フィルタを実行する
-     * Then フィルタチェーン実行後にMDCからトレースIDが削除される
-     * </pre>
-     */
-    @Test
-    @DisplayName("フィルタチェーン実行後にトレースIDが削除されること")
-    void shouldRemoveTraceIdAfterFilterChainIsFinished() {
-        TraceIdFilter traceIdFilter = new TraceIdFilter();
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        FilterChain filterChain = (req, res) -> {
-        };
-
-        assertDoesNotThrow(() -> traceIdFilter.doFilter(request, response, filterChain));
-
-        assertNull(MDC.get(TraceIdFilter.TRACE_ID_KEY));
-    }
-
-    /**
-     * UUID形式かどうかを判定する
-     *
-     * @param value UUID形式判定対象文字列
-     * @return UUID形式の場合 true
-     */
-    private boolean isUuid(final String value) {
-        if (value == null) {
-            return false;
-        }
-
-        try {
-            UUID.fromString(value);
-            return true;
-        } catch (IllegalArgumentException ex) {
-            return false;
-        }
-    }
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/presentation/order/OrderControllerTest.java
@@ -1,5 +1,14 @@
 package jp.co.shimizutdev.phoneorderapi.presentation.order;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import jp.co.shimizutdev.phoneorderapi.application.order.OrderService;
 import jp.co.shimizutdev.phoneorderapi.domain.common.PagingCondition;
 import jp.co.shimizutdev.phoneorderapi.domain.order.OrderCode;
@@ -19,666 +28,758 @@ import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import org.springframework.test.context.jdbc.SqlMergeMode;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.hamcrest.Matchers.hasSize;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-/**
- * 注文コントローラテスト
- */
+/** 注文コントローラテスト */
 @SpringBootTest
 @AutoConfigureMockMvc
 @SqlMergeMode(MERGE)
 @Sql(
     scripts = "classpath:sql/cleanup/cleanup-transaction-tables.sql",
-    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD
-)
+    executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(
     scripts = "classpath:sql/cleanup/cleanup-transaction-tables.sql",
-    executionPhase = ExecutionPhase.AFTER_TEST_METHOD
-)
+    executionPhase = ExecutionPhase.AFTER_TEST_METHOD)
 class OrderControllerTest extends AbstractPostgreSQLTest {
 
-    /**
-     * MockMvc
-     */
-    @Autowired
-    private MockMvc mockMvc;
+  /** MockMvc */
+  @Autowired private MockMvc mockMvc;
+
+  /** 注文サービス */
+  @MockitoSpyBean private OrderService orderService;
+
+  @Nested
+  @DisplayName("GET /api/v1/orders")
+  class GetOrders {
 
     /**
-     * 注文サービス
+     *
+     *
+     * <pre>
+     * Given 注文データが複数件登録されている
+     * When 注文一覧取得APIを実行する
+     * Then 200 OK とページング済み注文一覧レスポンスが返る
+     * </pre>
      */
-    @MockitoSpyBean
-    private OrderService orderService;
-
-    @Nested
-    @DisplayName("GET /api/v1/orders")
-    class GetOrders {
-
-        /**
-         * <pre>
-         * Given 注文データが複数件登録されている
-         * When 注文一覧取得APIを実行する
-         * Then 200 OK とページング済み注文一覧レスポンスが返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文一覧を取得できること")
-        @Sql(statements = {
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001', '2026-04-07T10:15:30+09:00', '001', 0, 'system', 'system')",
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000002', 'ORD000002', '2026-04-07T11:00:00+09:00', '002', 1, 'system', 'system')"
+    @Test
+    @DisplayName("注文一覧を取得できること")
+    @Sql(
+        statements = {
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001',"
+              + " '2026-04-07T10:15:30+09:00', '001', 0, 'system', 'system')",
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000002', 'ORD000002',"
+              + " '2026-04-07T11:00:00+09:00', '002', 1, 'system', 'system')"
         })
-        void shouldReturnOrdersWhenGetOrders() throws Exception {
-            mockMvc.perform(get("/api/v1/orders"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.items", hasSize(2)))
-                .andExpect(jsonPath("$.items[0].orderCode").value("ORD000002"))
-                .andExpect(jsonPath("$.items[0].orderedAt").value("2026-04-07T02:00:00Z"))
-                .andExpect(jsonPath("$.items[0].orderStatus").value("002"))
-                .andExpect(jsonPath("$.items[0].version").value(1))
-                .andExpect(jsonPath("$.items[1].orderCode").value("ORD000001"))
-                .andExpect(jsonPath("$.items[1].orderedAt").value("2026-04-07T01:15:30Z"))
-                .andExpect(jsonPath("$.items[1].orderStatus").value("001"))
-                .andExpect(jsonPath("$.items[1].version").value(0))
-                .andExpect(jsonPath("$.page").value(0))
-                .andExpect(jsonPath("$.size").value(20))
-                .andExpect(jsonPath("$.totalElements").value(2))
-                .andExpect(jsonPath("$.totalPages").value(1))
-                .andExpect(jsonPath("$.hasNext").value(false))
-                .andExpect(jsonPath("$.hasPrevious").value(false));
-        }
-
-        /**
-         * <pre>
-         * Given 注文データが3件登録されている
-         * When page と size を指定して注文一覧取得APIを実行する
-         * Then 指定ページの注文一覧とページ情報が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文一覧をページ指定で取得できること")
-        @Sql(statements = {
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001', '2026-04-07T10:00:00+09:00', '001', 0, 'system', 'system')",
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000002', 'ORD000002', '2026-04-07T11:00:00+09:00', '001', 0, 'system', 'system')",
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000003', 'ORD000003', '2026-04-07T12:00:00+09:00', '001', 0, 'system', 'system')"
-        })
-        void shouldReturnOrdersWhenPageAndSizeAreSpecified() throws Exception {
-            mockMvc.perform(get("/api/v1/orders")
-                    .param("page", "1")
-                    .param("size", "2"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.items", hasSize(1)))
-                .andExpect(jsonPath("$.items[0].orderCode").value("ORD000001"))
-                .andExpect(jsonPath("$.items[0].orderedAt").value("2026-04-07T01:00:00Z"))
-                .andExpect(jsonPath("$.items[0].orderStatus").value("001"))
-                .andExpect(jsonPath("$.items[0].version").value(0))
-                .andExpect(jsonPath("$.page").value(1))
-                .andExpect(jsonPath("$.size").value(2))
-                .andExpect(jsonPath("$.totalElements").value(3))
-                .andExpect(jsonPath("$.totalPages").value(2))
-                .andExpect(jsonPath("$.hasNext").value(false))
-                .andExpect(jsonPath("$.hasPrevious").value(true));
-        }
-
-        /**
-         * <pre>
-         * Given 注文データが2件登録されている
-         * When 総ページ数を超える page を指定して注文一覧取得APIを実行する
-         * Then 空の注文一覧と指定ページのページ情報が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("範囲外ページは空ページを返すこと")
-        @Sql(statements = {
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001', '2026-04-07T10:00:00+09:00', '001', 0, 'system', 'system')",
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000002', 'ORD000002', '2026-04-07T11:00:00+09:00', '001', 0, 'system', 'system')"
-        })
-        void shouldReturnEmptyPageWhenPageIsOutOfRange() throws Exception {
-            mockMvc.perform(get("/api/v1/orders")
-                    .param("page", "2")
-                    .param("size", "2"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.items", hasSize(0)))
-                .andExpect(jsonPath("$.page").value(2))
-                .andExpect(jsonPath("$.size").value(2))
-                .andExpect(jsonPath("$.totalElements").value(2))
-                .andExpect(jsonPath("$.totalPages").value(1))
-                .andExpect(jsonPath("$.hasNext").value(false))
-                .andExpect(jsonPath("$.hasPrevious").value(true));
-        }
-
-        /**
-         * <pre>
-         * Given 不正な page を用意する
-         * When 注文一覧取得APIを実行する
-         * Then 400 Bad Request と入力エラー情報が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("pageが不正な場合は400を返すこと")
-        void shouldReturnBadRequestWhenPageIsInvalid() throws Exception {
-            mockMvc.perform(get("/api/v1/orders")
-                    .param("page", "-1"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(1)))
-                .andExpect(jsonPath("$.validationErrors[0].field").value("page"))
-                .andExpect(jsonPath("$.validationErrors[0].message").isString());
-        }
-
-        /**
-         * <pre>
-         * Given 不正な size を用意する
-         * When 注文一覧取得APIを実行する
-         * Then 400 Bad Request と入力エラー情報が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("sizeが不正な場合は400を返すこと")
-        void shouldReturnBadRequestWhenSizeIsInvalid() throws Exception {
-            mockMvc.perform(get("/api/v1/orders")
-                    .param("size", "101"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(1)))
-                .andExpect(jsonPath("$.validationErrors[0].field").value("size"))
-                .andExpect(jsonPath("$.validationErrors[0].message").isString());
-        }
-
-        /**
-         * <pre>
-         * Given 注文サービスでRuntimeExceptionが発生する
-         * When 注文一覧取得APIを実行する
-         * Then 500 Internal Server Errorが返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文一覧取得時に想定外エラーが発生した場合は500を返すこと")
-        void shouldReturnInternalServerErrorWhenUnexpectedErrorOccurs() throws Exception {
-            doThrow(new RuntimeException("unexpected error occurred"))
-                .when(orderService)
-                .getOrders(any(PagingCondition.class));
-
-            mockMvc.perform(get("/api/v1/orders"))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.status").value(500))
-                .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
+    void shouldReturnOrdersWhenGetOrders() throws Exception {
+      mockMvc
+          .perform(get("/api/v1/orders"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.items", hasSize(2)))
+          .andExpect(jsonPath("$.items[0].orderCode").value("ORD000002"))
+          .andExpect(jsonPath("$.items[0].orderedAt").value("2026-04-07T02:00:00Z"))
+          .andExpect(jsonPath("$.items[0].orderStatus").value("002"))
+          .andExpect(jsonPath("$.items[0].version").value(1))
+          .andExpect(jsonPath("$.items[1].orderCode").value("ORD000001"))
+          .andExpect(jsonPath("$.items[1].orderedAt").value("2026-04-07T01:15:30Z"))
+          .andExpect(jsonPath("$.items[1].orderStatus").value("001"))
+          .andExpect(jsonPath("$.items[1].version").value(0))
+          .andExpect(jsonPath("$.page").value(0))
+          .andExpect(jsonPath("$.size").value(20))
+          .andExpect(jsonPath("$.totalElements").value(2))
+          .andExpect(jsonPath("$.totalPages").value(1))
+          .andExpect(jsonPath("$.hasNext").value(false))
+          .andExpect(jsonPath("$.hasPrevious").value(false));
     }
 
-    @Nested
-    @DisplayName("GET /api/v1/orders/{orderCode}")
-    class GetOrderByOrderCode {
-
-        /**
-         * <pre>
-         * Given 注文データが登録されている
-         * When 注文コードで注文取得APIを実行する
-         * Then 200 OK と注文情報が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文コードで注文を取得できること")
-        @Sql(statements = {
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001', '2026-04-07T10:15:30+09:00', '001', 2, 'system', 'system')"
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文データが3件登録されている
+     * When page と size を指定して注文一覧取得APIを実行する
+     * Then 指定ページの注文一覧とページ情報が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文一覧をページ指定で取得できること")
+    @Sql(
+        statements = {
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001',"
+              + " '2026-04-07T10:00:00+09:00', '001', 0, 'system', 'system')",
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000002', 'ORD000002',"
+              + " '2026-04-07T11:00:00+09:00', '001', 0, 'system', 'system')",
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000003', 'ORD000003',"
+              + " '2026-04-07T12:00:00+09:00', '001', 0, 'system', 'system')"
         })
-        void shouldReturnOrderWhenOrderCodeExists() throws Exception {
-            mockMvc.perform(get("/api/v1/orders/{orderCode}", "ORD000001"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.orderCode").value("ORD000001"))
-                .andExpect(jsonPath("$.orderedAt").value("2026-04-07T01:15:30Z"))
-                .andExpect(jsonPath("$.orderStatus").value("001"))
-                .andExpect(jsonPath("$.version").value(2));
-        }
-
-        /**
-         * <pre>
-         * Given 対象注文が登録されていない
-         * When 注文コードで注文取得APIを実行する
-         * Then 404 Not Found が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文コードに対応する注文が存在しない場合は404を返すこと")
-        void shouldReturnNotFoundWhenOrderCodeDoesNotExist() throws Exception {
-            mockMvc.perform(get("/api/v1/orders/{orderCode}", "ORD999999"))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.error").value("NOT_FOUND"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.ORDER_NOT_FOUND))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD999999"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
-
-        /**
-         * <pre>
-         * Given 不正形式の注文コードを用意する
-         * When 注文コードで注文取得APIを実行する
-         * Then 400 Bad Request が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文コード形式が不正な場合は400を返すこと")
-        void shouldReturnBadRequestWhenOrderCodeFormatIsInvalid() throws Exception {
-            mockMvc.perform(get("/api/v1/orders/{orderCode}", "INVALID"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders/INVALID"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(2)))
-                .andExpect(jsonPath("$.validationErrors[0].field").value("orderCode"))
-                .andExpect(jsonPath("$.validationErrors[0].message").isString())
-                .andExpect(jsonPath("$.validationErrors[1].field").value("orderCode"))
-                .andExpect(jsonPath("$.validationErrors[1].message").isString());
-        }
-
-        /**
-         * <pre>
-         * Given 注文サービスでRuntimeExceptionが発生する
-         * When 注文コードで注文取得APIを実行する
-         * Then 500 Internal Server Error が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文取得時に想定外エラーが発生した場合は500を返すこと")
-        void shouldReturnInternalServerErrorWhenGetOrderUnexpectedErrorOccurs() throws Exception {
-            doThrow(new RuntimeException("unexpected error occurred"))
-                .when(orderService)
-                .getOrderByOrderCode(OrderCode.of("ORD000001"));
-
-            mockMvc.perform(get("/api/v1/orders/{orderCode}", "ORD000001"))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.status").value(500))
-                .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
-
-        /**
-         * <pre>
-         * Given DBに不正な注文ステータスの注文データが登録されている
-         * When 注文コードで注文取得APIを実行する
-         * Then 500 Internal Server Error が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("DB上の注文ステータスが不正な場合は500を返すこと")
-        @Sql(statements = {
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001', '2026-04-07T10:15:30+09:00', '999', 0, 'system', 'system')"
-        })
-        void shouldReturnInternalServerErrorWhenPersistedOrderStatusIsInvalid() throws Exception {
-            mockMvc.perform(get("/api/v1/orders/{orderCode}", "ORD000001"))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.status").value(500))
-                .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
+    void shouldReturnOrdersWhenPageAndSizeAreSpecified() throws Exception {
+      mockMvc
+          .perform(get("/api/v1/orders").param("page", "1").param("size", "2"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.items", hasSize(1)))
+          .andExpect(jsonPath("$.items[0].orderCode").value("ORD000001"))
+          .andExpect(jsonPath("$.items[0].orderedAt").value("2026-04-07T01:00:00Z"))
+          .andExpect(jsonPath("$.items[0].orderStatus").value("001"))
+          .andExpect(jsonPath("$.items[0].version").value(0))
+          .andExpect(jsonPath("$.page").value(1))
+          .andExpect(jsonPath("$.size").value(2))
+          .andExpect(jsonPath("$.totalElements").value(3))
+          .andExpect(jsonPath("$.totalPages").value(2))
+          .andExpect(jsonPath("$.hasNext").value(false))
+          .andExpect(jsonPath("$.hasPrevious").value(true));
     }
 
-    @Nested
-    @DisplayName("POST /api/v1/orders")
-    class CreateOrder {
-
-        /**
-         * <pre>
-         * Given 正常な注文リクエストを用意する
-         * When 注文登録APIを実行する
-         * Then 201 Created と登録された注文情報が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文を登録できること")
-        void shouldCreateOrderWhenRequestIsValid() throws Exception {
-            String requestBody = """
-                {
-                  "orderedAt": "2026-04-07T10:15:30+09:00"
-                }
-                """;
-
-            mockMvc.perform(post("/api/v1/orders")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody))
-                .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.orderCode").value("ORD000001"))
-                .andExpect(jsonPath("$.orderedAt").value("2026-04-07T01:15:30Z"))
-                .andExpect(jsonPath("$.orderStatus").value("001"))
-                .andExpect(jsonPath("$.version").value(0));
-        }
-
-        /**
-         * <pre>
-         * Given 必須項目が不足したリクエストを用意する
-         * When 注文登録APIを実行する
-         * Then 400 Bad Request と入力エラー情報が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("必須項目が不足している場合は400を返すこと")
-        void shouldReturnBadRequestWhenRequiredFieldsAreMissing() throws Exception {
-            mockMvc.perform(post("/api/v1/orders")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content("{ }"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value("入力値が不正です。"))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(1)))
-                .andExpect(jsonPath("$.validationErrors[0].field").value("orderedAt"))
-                .andExpect(jsonPath("$.validationErrors[0].message").value("必須項目です。"));
-        }
-
-        /**
-         * <pre>
-         * Given 不正形式のリクエストボディを用意する
-         * When 注文登録APIを実行する
-         * Then 400 Bad Request と形式不正メッセージが返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("不正形式のリクエストボディの場合は400を返すこと")
-        void shouldReturnBadRequestWhenRequestBodyFormatIsInvalid() throws Exception {
-            String requestBody = """
-                {
-                  "orderedAt": "invalid-date-time"
-                }
-                """;
-
-            mockMvc.perform(post("/api/v1/orders")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value("リクエストボディの形式が不正です。"))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
-
-        /**
-         * <pre>
-         * Given 50文字を超える X-User-Id を含む注文リクエストを用意する
-         * When 注文登録APIを実行する
-         * Then 400 Bad Request と監査ユーザー不正メッセージが返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("X-User-Idが50文字を超える場合は400を返すこと")
-        void shouldReturnBadRequestWhenUserIdHeaderIsTooLong() throws Exception {
-            String requestBody = """
-                {
-                  "orderedAt": "2026-04-07T10:15:30+09:00"
-                }
-                """;
-
-            mockMvc.perform(post("/api/v1/orders")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("X-User-Id", "a".repeat(51))
-                    .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.INVALID_AUDITOR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
-
-        /**
-         * <pre>
-         * Given 注文サービスでRuntimeExceptionが発生する
-         * When 注文登録APIを実行する
-         * Then 500 Internal Server Error が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文登録時に想定外エラーが発生した場合は500を返すこと")
-        void shouldReturnInternalServerErrorWhenCreateOrderUnexpectedErrorOccurs() throws Exception {
-            String requestBody = """
-                {
-                  "orderedAt": "2026-04-07T10:15:30+09:00"
-                }
-                """;
-
-            doThrow(new RuntimeException("unexpected error occurred"))
-                .when(orderService)
-                .createOrder(any());
-
-            mockMvc.perform(post("/api/v1/orders")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.status").value(500))
-                .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文データが2件登録されている
+     * When 総ページ数を超える page を指定して注文一覧取得APIを実行する
+     * Then 空の注文一覧と指定ページのページ情報が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("範囲外ページは空ページを返すこと")
+    @Sql(
+        statements = {
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001',"
+              + " '2026-04-07T10:00:00+09:00', '001', 0, 'system', 'system')",
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000002', 'ORD000002',"
+              + " '2026-04-07T11:00:00+09:00', '001', 0, 'system', 'system')"
+        })
+    void shouldReturnEmptyPageWhenPageIsOutOfRange() throws Exception {
+      mockMvc
+          .perform(get("/api/v1/orders").param("page", "2").param("size", "2"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.items", hasSize(0)))
+          .andExpect(jsonPath("$.page").value(2))
+          .andExpect(jsonPath("$.size").value(2))
+          .andExpect(jsonPath("$.totalElements").value(2))
+          .andExpect(jsonPath("$.totalPages").value(1))
+          .andExpect(jsonPath("$.hasNext").value(false))
+          .andExpect(jsonPath("$.hasPrevious").value(true));
     }
 
-    @Nested
-    @DisplayName("POST /api/v1/orders/{orderCode}/cancel")
-    class CancelOrder {
-
-        /**
-         * <pre>
-         * Given 注文データが登録されている
-         * When 注文キャンセルAPIを実行する
-         * Then 200 OK とキャンセル済み注文情報が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文をキャンセルできること")
-        @Sql(statements = {
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001', '2026-04-07T10:15:30+09:00', '001', 0, 'system', 'system')"
-        })
-        void shouldCancelOrderWhenOrderExists() throws Exception {
-            String requestBody = """
-                {
-                  "version": 0
-                }
-                """;
-
-            mockMvc.perform(post("/api/v1/orders/{orderCode}/cancel", "ORD000001")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.orderCode").value("ORD000001"))
-                .andExpect(jsonPath("$.orderedAt").value("2026-04-07T01:15:30Z"))
-                .andExpect(jsonPath("$.orderStatus").value("006"))
-                .andExpect(jsonPath("$.version").value(1));
-        }
-
-        /**
-         * <pre>
-         * Given versionが不足したキャンセルリクエストを用意する
-         * When 注文キャンセルAPIを実行する
-         * Then 400 Bad Request と入力エラー情報が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("version未指定は400になる")
-        @Sql(statements = {
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001', '2026-04-07T10:15:30+09:00', '001', 0, 'system', 'system')"
-        })
-        void shouldReturnBadRequestWhenVersionIsMissing() throws Exception {
-            mockMvc.perform(post("/api/v1/orders/{orderCode}/cancel", "ORD000001")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content("{ }"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001/cancel"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(1)))
-                .andExpect(jsonPath("$.validationErrors[0].field").value("version"))
-                .andExpect(jsonPath("$.validationErrors[0].message").value("必須項目です。"));
-        }
-
-        /**
-         * <pre>
-         * Given 対象注文が登録されていない
-         * When 注文キャンセルAPIを実行する
-         * Then 404 Not Found が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文コードに対応する注文が存在しない場合は404を返すこと")
-        void shouldReturnNotFoundWhenCancelTargetDoesNotExist() throws Exception {
-            String requestBody = """
-                {
-                  "version": 0
-                }
-                """;
-
-            mockMvc.perform(post("/api/v1/orders/{orderCode}/cancel", "ORD999999")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.status").value(404))
-                .andExpect(jsonPath("$.error").value("NOT_FOUND"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.ORDER_NOT_FOUND))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD999999/cancel"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
-
-        /**
-         * <pre>
-         * Given 不正形式の注文コードを用意する
-         * When 注文キャンセルAPIを実行する
-         * Then 400 Bad Request が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("キャンセル対象の注文コード形式が不正な場合は400を返すこと")
-        void shouldReturnBadRequestWhenCancelTargetOrderCodeFormatIsInvalid() throws Exception {
-            String requestBody = """
-                {
-                  "version": 0
-                }
-                """;
-
-            mockMvc.perform(post("/api/v1/orders/{orderCode}/cancel", "INVALID")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders/INVALID/cancel"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(2)))
-                .andExpect(jsonPath("$.validationErrors[0].field").value("orderCode"))
-                .andExpect(jsonPath("$.validationErrors[0].message").isString())
-                .andExpect(jsonPath("$.validationErrors[1].field").value("orderCode"))
-                .andExpect(jsonPath("$.validationErrors[1].message").isString());
-        }
-
-        /**
-         * <pre>
-         * Given 完了状態の注文データが登録されている
-         * When 注文キャンセルAPIを実行する
-         * Then 409 Conflict が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("キャンセル不可状態の注文は409を返すこと")
-        @Sql(statements = {
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001', '2026-04-07T10:15:30+09:00', '005', 0, 'system', 'system')"
-        })
-        void shouldReturnConflictWhenOrderCannotBeCancelled() throws Exception {
-            String requestBody = """
-                {
-                  "version": 0
-                }
-                """;
-
-            mockMvc.perform(post("/api/v1/orders/{orderCode}/cancel", "ORD000001")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.status").value(409))
-                .andExpect(jsonPath("$.error").value("CONFLICT"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.ORDER_CANNOT_BE_CANCELLED))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001/cancel"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
-
-        /**
-         * <pre>
-         * Given 対象注文が登録されている
-         * When 古いversionで注文キャンセルAPIを実行する
-         * Then 409 Conflict が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("stale version は409になる")
-        @Sql(statements = {
-            "insert into orders (id, order_code, ordered_at, order_status, version, created_by, updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001', '2026-04-07T10:15:30+09:00', '001', 0, 'system', 'system')"
-        })
-        void shouldReturnConflictWhenVersionDoesNotMatch() throws Exception {
-            String requestBody = """
-                {
-                  "version": 1
-                }
-                """;
-
-            mockMvc.perform(post("/api/v1/orders/{orderCode}/cancel", "ORD000001")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody))
-                .andExpect(status().isConflict())
-                .andExpect(jsonPath("$.status").value(409))
-                .andExpect(jsonPath("$.error").value("CONFLICT"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.ORDER_VERSION_CONFLICT))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001/cancel"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
-
-        /**
-         * <pre>
-         * Given 注文サービスでRuntimeExceptionが発生する
-         * When 注文キャンセルAPIを実行する
-         * Then 500 Internal Server Error が返る
-         * </pre>
-         */
-        @Test
-        @DisplayName("注文キャンセル時に想定外エラーが発生した場合は500を返すこと")
-        void shouldReturnInternalServerErrorWhenCancelOrderUnexpectedErrorOccurs() throws Exception {
-            String requestBody = """
-                {
-                  "version": 0
-                }
-                """;
-
-            doThrow(new RuntimeException("unexpected error occurred"))
-                .when(orderService)
-                .cancelOrder(OrderCode.of("ORD000001"), Version.of(0L));
-
-            mockMvc.perform(post("/api/v1/orders/{orderCode}/cancel", "ORD000001")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(requestBody))
-                .andExpect(status().isInternalServerError())
-                .andExpect(jsonPath("$.status").value(500))
-                .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
-                .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
-                .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001/cancel"))
-                .andExpect(jsonPath("$.validationErrors", hasSize(0)));
-        }
+    /**
+     *
+     *
+     * <pre>
+     * Given 不正な page を用意する
+     * When 注文一覧取得APIを実行する
+     * Then 400 Bad Request と入力エラー情報が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("pageが不正な場合は400を返すこと")
+    void shouldReturnBadRequestWhenPageIsInvalid() throws Exception {
+      mockMvc
+          .perform(get("/api/v1/orders").param("page", "-1"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400))
+          .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(1)))
+          .andExpect(jsonPath("$.validationErrors[0].field").value("page"))
+          .andExpect(jsonPath("$.validationErrors[0].message").isString());
     }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 不正な size を用意する
+     * When 注文一覧取得APIを実行する
+     * Then 400 Bad Request と入力エラー情報が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("sizeが不正な場合は400を返すこと")
+    void shouldReturnBadRequestWhenSizeIsInvalid() throws Exception {
+      mockMvc
+          .perform(get("/api/v1/orders").param("size", "101"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400))
+          .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(1)))
+          .andExpect(jsonPath("$.validationErrors[0].field").value("size"))
+          .andExpect(jsonPath("$.validationErrors[0].message").isString());
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文サービスでRuntimeExceptionが発生する
+     * When 注文一覧取得APIを実行する
+     * Then 500 Internal Server Errorが返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文一覧取得時に想定外エラーが発生した場合は500を返すこと")
+    void shouldReturnInternalServerErrorWhenUnexpectedErrorOccurs() throws Exception {
+      doThrow(new RuntimeException("unexpected error occurred"))
+          .when(orderService)
+          .getOrders(any(PagingCondition.class));
+
+      mockMvc
+          .perform(get("/api/v1/orders"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(jsonPath("$.status").value(500))
+          .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /api/v1/orders/{orderCode}")
+  class GetOrderByOrderCode {
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文データが登録されている
+     * When 注文コードで注文取得APIを実行する
+     * Then 200 OK と注文情報が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文コードで注文を取得できること")
+    @Sql(
+        statements = {
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001',"
+              + " '2026-04-07T10:15:30+09:00', '001', 2, 'system', 'system')"
+        })
+    void shouldReturnOrderWhenOrderCodeExists() throws Exception {
+      mockMvc
+          .perform(get("/api/v1/orders/{orderCode}", "ORD000001"))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.orderCode").value("ORD000001"))
+          .andExpect(jsonPath("$.orderedAt").value("2026-04-07T01:15:30Z"))
+          .andExpect(jsonPath("$.orderStatus").value("001"))
+          .andExpect(jsonPath("$.version").value(2));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 対象注文が登録されていない
+     * When 注文コードで注文取得APIを実行する
+     * Then 404 Not Found が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文コードに対応する注文が存在しない場合は404を返すこと")
+    void shouldReturnNotFoundWhenOrderCodeDoesNotExist() throws Exception {
+      mockMvc
+          .perform(get("/api/v1/orders/{orderCode}", "ORD999999"))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.status").value(404))
+          .andExpect(jsonPath("$.error").value("NOT_FOUND"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.ORDER_NOT_FOUND))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD999999"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 不正形式の注文コードを用意する
+     * When 注文コードで注文取得APIを実行する
+     * Then 400 Bad Request が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文コード形式が不正な場合は400を返すこと")
+    void shouldReturnBadRequestWhenOrderCodeFormatIsInvalid() throws Exception {
+      mockMvc
+          .perform(get("/api/v1/orders/{orderCode}", "INVALID"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400))
+          .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders/INVALID"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(2)))
+          .andExpect(jsonPath("$.validationErrors[0].field").value("orderCode"))
+          .andExpect(jsonPath("$.validationErrors[0].message").isString())
+          .andExpect(jsonPath("$.validationErrors[1].field").value("orderCode"))
+          .andExpect(jsonPath("$.validationErrors[1].message").isString());
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文サービスでRuntimeExceptionが発生する
+     * When 注文コードで注文取得APIを実行する
+     * Then 500 Internal Server Error が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文取得時に想定外エラーが発生した場合は500を返すこと")
+    void shouldReturnInternalServerErrorWhenGetOrderUnexpectedErrorOccurs() throws Exception {
+      doThrow(new RuntimeException("unexpected error occurred"))
+          .when(orderService)
+          .getOrderByOrderCode(OrderCode.of("ORD000001"));
+
+      mockMvc
+          .perform(get("/api/v1/orders/{orderCode}", "ORD000001"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(jsonPath("$.status").value(500))
+          .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given DBに不正な注文ステータスの注文データが登録されている
+     * When 注文コードで注文取得APIを実行する
+     * Then 500 Internal Server Error が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("DB上の注文ステータスが不正な場合は500を返すこと")
+    @Sql(
+        statements = {
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001',"
+              + " '2026-04-07T10:15:30+09:00', '999', 0, 'system', 'system')"
+        })
+    void shouldReturnInternalServerErrorWhenPersistedOrderStatusIsInvalid() throws Exception {
+      mockMvc
+          .perform(get("/api/v1/orders/{orderCode}", "ORD000001"))
+          .andExpect(status().isInternalServerError())
+          .andExpect(jsonPath("$.status").value(500))
+          .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /api/v1/orders")
+  class CreateOrder {
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 正常な注文リクエストを用意する
+     * When 注文登録APIを実行する
+     * Then 201 Created と登録された注文情報が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文を登録できること")
+    void shouldCreateOrderWhenRequestIsValid() throws Exception {
+      String requestBody =
+          """
+          {
+            "orderedAt": "2026-04-07T10:15:30+09:00"
+          }
+          """;
+
+      mockMvc
+          .perform(
+              post("/api/v1/orders").contentType(MediaType.APPLICATION_JSON).content(requestBody))
+          .andExpect(status().isCreated())
+          .andExpect(jsonPath("$.orderCode").value("ORD000001"))
+          .andExpect(jsonPath("$.orderedAt").value("2026-04-07T01:15:30Z"))
+          .andExpect(jsonPath("$.orderStatus").value("001"))
+          .andExpect(jsonPath("$.version").value(0));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 必須項目が不足したリクエストを用意する
+     * When 注文登録APIを実行する
+     * Then 400 Bad Request と入力エラー情報が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("必須項目が不足している場合は400を返すこと")
+    void shouldReturnBadRequestWhenRequiredFieldsAreMissing() throws Exception {
+      mockMvc
+          .perform(post("/api/v1/orders").contentType(MediaType.APPLICATION_JSON).content("{ }"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400))
+          .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+          .andExpect(jsonPath("$.message").value("入力値が不正です。"))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(1)))
+          .andExpect(jsonPath("$.validationErrors[0].field").value("orderedAt"))
+          .andExpect(jsonPath("$.validationErrors[0].message").value("必須項目です。"));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 不正形式のリクエストボディを用意する
+     * When 注文登録APIを実行する
+     * Then 400 Bad Request と形式不正メッセージが返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("不正形式のリクエストボディの場合は400を返すこと")
+    void shouldReturnBadRequestWhenRequestBodyFormatIsInvalid() throws Exception {
+      String requestBody =
+          """
+          {
+            "orderedAt": "invalid-date-time"
+          }
+          """;
+
+      mockMvc
+          .perform(
+              post("/api/v1/orders").contentType(MediaType.APPLICATION_JSON).content(requestBody))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400))
+          .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+          .andExpect(jsonPath("$.message").value("リクエストボディの形式が不正です。"))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 50文字を超える X-User-Id を含む注文リクエストを用意する
+     * When 注文登録APIを実行する
+     * Then 400 Bad Request と監査ユーザー不正メッセージが返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("X-User-Idが50文字を超える場合は400を返すこと")
+    void shouldReturnBadRequestWhenUserIdHeaderIsTooLong() throws Exception {
+      String requestBody =
+          """
+          {
+            "orderedAt": "2026-04-07T10:15:30+09:00"
+          }
+          """;
+
+      mockMvc
+          .perform(
+              post("/api/v1/orders")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .header("X-User-Id", "a".repeat(51))
+                  .content(requestBody))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400))
+          .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.INVALID_AUDITOR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文サービスでRuntimeExceptionが発生する
+     * When 注文登録APIを実行する
+     * Then 500 Internal Server Error が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文登録時に想定外エラーが発生した場合は500を返すこと")
+    void shouldReturnInternalServerErrorWhenCreateOrderUnexpectedErrorOccurs() throws Exception {
+      String requestBody =
+          """
+          {
+            "orderedAt": "2026-04-07T10:15:30+09:00"
+          }
+          """;
+
+      doThrow(new RuntimeException("unexpected error occurred"))
+          .when(orderService)
+          .createOrder(any());
+
+      mockMvc
+          .perform(
+              post("/api/v1/orders").contentType(MediaType.APPLICATION_JSON).content(requestBody))
+          .andExpect(status().isInternalServerError())
+          .andExpect(jsonPath("$.status").value(500))
+          .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+  }
+
+  @Nested
+  @DisplayName("POST /api/v1/orders/{orderCode}/cancel")
+  class CancelOrder {
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文データが登録されている
+     * When 注文キャンセルAPIを実行する
+     * Then 200 OK とキャンセル済み注文情報が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文をキャンセルできること")
+    @Sql(
+        statements = {
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001',"
+              + " '2026-04-07T10:15:30+09:00', '001', 0, 'system', 'system')"
+        })
+    void shouldCancelOrderWhenOrderExists() throws Exception {
+      String requestBody =
+          """
+          {
+            "version": 0
+          }
+          """;
+
+      mockMvc
+          .perform(
+              post("/api/v1/orders/{orderCode}/cancel", "ORD000001")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(requestBody))
+          .andExpect(status().isOk())
+          .andExpect(jsonPath("$.orderCode").value("ORD000001"))
+          .andExpect(jsonPath("$.orderedAt").value("2026-04-07T01:15:30Z"))
+          .andExpect(jsonPath("$.orderStatus").value("006"))
+          .andExpect(jsonPath("$.version").value(1));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given versionが不足したキャンセルリクエストを用意する
+     * When 注文キャンセルAPIを実行する
+     * Then 400 Bad Request と入力エラー情報が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("version未指定は400になる")
+    @Sql(
+        statements = {
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001',"
+              + " '2026-04-07T10:15:30+09:00', '001', 0, 'system', 'system')"
+        })
+    void shouldReturnBadRequestWhenVersionIsMissing() throws Exception {
+      mockMvc
+          .perform(
+              post("/api/v1/orders/{orderCode}/cancel", "ORD000001")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content("{ }"))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400))
+          .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001/cancel"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(1)))
+          .andExpect(jsonPath("$.validationErrors[0].field").value("version"))
+          .andExpect(jsonPath("$.validationErrors[0].message").value("必須項目です。"));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 対象注文が登録されていない
+     * When 注文キャンセルAPIを実行する
+     * Then 404 Not Found が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文コードに対応する注文が存在しない場合は404を返すこと")
+    void shouldReturnNotFoundWhenCancelTargetDoesNotExist() throws Exception {
+      String requestBody =
+          """
+          {
+            "version": 0
+          }
+          """;
+
+      mockMvc
+          .perform(
+              post("/api/v1/orders/{orderCode}/cancel", "ORD999999")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(requestBody))
+          .andExpect(status().isNotFound())
+          .andExpect(jsonPath("$.status").value(404))
+          .andExpect(jsonPath("$.error").value("NOT_FOUND"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.ORDER_NOT_FOUND))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD999999/cancel"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 不正形式の注文コードを用意する
+     * When 注文キャンセルAPIを実行する
+     * Then 400 Bad Request が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("キャンセル対象の注文コード形式が不正な場合は400を返すこと")
+    void shouldReturnBadRequestWhenCancelTargetOrderCodeFormatIsInvalid() throws Exception {
+      String requestBody =
+          """
+          {
+            "version": 0
+          }
+          """;
+
+      mockMvc
+          .perform(
+              post("/api/v1/orders/{orderCode}/cancel", "INVALID")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(requestBody))
+          .andExpect(status().isBadRequest())
+          .andExpect(jsonPath("$.status").value(400))
+          .andExpect(jsonPath("$.error").value("BAD_REQUEST"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.VALIDATION_ERROR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders/INVALID/cancel"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(2)))
+          .andExpect(jsonPath("$.validationErrors[0].field").value("orderCode"))
+          .andExpect(jsonPath("$.validationErrors[0].message").isString())
+          .andExpect(jsonPath("$.validationErrors[1].field").value("orderCode"))
+          .andExpect(jsonPath("$.validationErrors[1].message").isString());
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 完了状態の注文データが登録されている
+     * When 注文キャンセルAPIを実行する
+     * Then 409 Conflict が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("キャンセル不可状態の注文は409を返すこと")
+    @Sql(
+        statements = {
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001',"
+              + " '2026-04-07T10:15:30+09:00', '005', 0, 'system', 'system')"
+        })
+    void shouldReturnConflictWhenOrderCannotBeCancelled() throws Exception {
+      String requestBody =
+          """
+          {
+            "version": 0
+          }
+          """;
+
+      mockMvc
+          .perform(
+              post("/api/v1/orders/{orderCode}/cancel", "ORD000001")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(requestBody))
+          .andExpect(status().isConflict())
+          .andExpect(jsonPath("$.status").value(409))
+          .andExpect(jsonPath("$.error").value("CONFLICT"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.ORDER_CANNOT_BE_CANCELLED))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001/cancel"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 対象注文が登録されている
+     * When 古いversionで注文キャンセルAPIを実行する
+     * Then 409 Conflict が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("stale version は409になる")
+    @Sql(
+        statements = {
+          "insert into orders (id, order_code, ordered_at, order_status, version, created_by,"
+              + " updated_by) values ('00000000-0000-0000-0000-000000000001', 'ORD000001',"
+              + " '2026-04-07T10:15:30+09:00', '001', 0, 'system', 'system')"
+        })
+    void shouldReturnConflictWhenVersionDoesNotMatch() throws Exception {
+      String requestBody =
+          """
+          {
+            "version": 1
+          }
+          """;
+
+      mockMvc
+          .perform(
+              post("/api/v1/orders/{orderCode}/cancel", "ORD000001")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(requestBody))
+          .andExpect(status().isConflict())
+          .andExpect(jsonPath("$.status").value(409))
+          .andExpect(jsonPath("$.error").value("CONFLICT"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.ORDER_VERSION_CONFLICT))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001/cancel"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+
+    /**
+     *
+     *
+     * <pre>
+     * Given 注文サービスでRuntimeExceptionが発生する
+     * When 注文キャンセルAPIを実行する
+     * Then 500 Internal Server Error が返る
+     * </pre>
+     */
+    @Test
+    @DisplayName("注文キャンセル時に想定外エラーが発生した場合は500を返すこと")
+    void shouldReturnInternalServerErrorWhenCancelOrderUnexpectedErrorOccurs() throws Exception {
+      String requestBody =
+          """
+          {
+            "version": 0
+          }
+          """;
+
+      doThrow(new RuntimeException("unexpected error occurred"))
+          .when(orderService)
+          .cancelOrder(OrderCode.of("ORD000001"), Version.of(0L));
+
+      mockMvc
+          .perform(
+              post("/api/v1/orders/{orderCode}/cancel", "ORD000001")
+                  .contentType(MediaType.APPLICATION_JSON)
+                  .content(requestBody))
+          .andExpect(status().isInternalServerError())
+          .andExpect(jsonPath("$.status").value(500))
+          .andExpect(jsonPath("$.error").value("INTERNAL_SERVER_ERROR"))
+          .andExpect(jsonPath("$.message").value(ApiErrorMessages.INTERNAL_SERVER_ERROR))
+          .andExpect(jsonPath("$.path").value("/api/v1/orders/ORD000001/cancel"))
+          .andExpect(jsonPath("$.validationErrors", hasSize(0)));
+    }
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/support/AbstractPostgreSQLTest.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/support/AbstractPostgreSQLTest.java
@@ -4,35 +4,31 @@ import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
 
-/**
- * PostgreSQLテスト共通設定
- */
+/** PostgreSQLテスト共通設定 */
 public abstract class AbstractPostgreSQLTest {
 
-    /**
-     * PostgreSQLコンテナ
-     */
-    @SuppressWarnings("resource")
-    protected static final PostgreSQLContainer<?> POSTGRESQL_CONTAINER =
-        new PostgreSQLContainer<>("postgres:16")
-            .withDatabaseName("phone_order_api_test_db")
-            .withUsername("test")
-            .withPassword("test");
+  /** PostgreSQLコンテナ */
+  @SuppressWarnings("resource")
+  protected static final PostgreSQLContainer<?> POSTGRESQL_CONTAINER =
+      new PostgreSQLContainer<>("postgres:16")
+          .withDatabaseName("phone_order_api_test_db")
+          .withUsername("test")
+          .withPassword("test");
 
-    static {
-        POSTGRESQL_CONTAINER.start();
-    }
+  static {
+    POSTGRESQL_CONTAINER.start();
+  }
 
-    /**
-     * テスト用データソースを設定する
-     *
-     * @param registry DynamicPropertyRegistry
-     */
-    @DynamicPropertySource
-    static void registerDataSourceProperties(final DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", POSTGRESQL_CONTAINER::getJdbcUrl);
-        registry.add("spring.datasource.username", POSTGRESQL_CONTAINER::getUsername);
-        registry.add("spring.datasource.password", POSTGRESQL_CONTAINER::getPassword);
-        registry.add("spring.datasource.driver-class-name", POSTGRESQL_CONTAINER::getDriverClassName);
-    }
+  /**
+   * テスト用データソースを設定する
+   *
+   * @param registry DynamicPropertyRegistry
+   */
+  @DynamicPropertySource
+  static void registerDataSourceProperties(final DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", POSTGRESQL_CONTAINER::getJdbcUrl);
+    registry.add("spring.datasource.username", POSTGRESQL_CONTAINER::getUsername);
+    registry.add("spring.datasource.password", POSTGRESQL_CONTAINER::getPassword);
+    registry.add("spring.datasource.driver-class-name", POSTGRESQL_CONTAINER::getDriverClassName);
+  }
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/support/ResetLogLevel.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/support/ResetLogLevel.java
@@ -1,24 +1,21 @@
 package jp.co.shimizutdev.phoneorderapi.support;
 
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-/**
- * テストクラスで変更したログレベルをテスト後に戻すアノテーション
- */
+/** テストクラスで変更したログレベルをテスト後に戻すアノテーション */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @ExtendWith(ResetLogLevelExtension.class)
 public @interface ResetLogLevel {
 
-    /**
-     * ログレベルを戻すロガークラス
-     *
-     * @return ロガークラス
-     */
-    Class<?>[] value();
+  /**
+   * ログレベルを戻すロガークラス
+   *
+   * @return ロガークラス
+   */
+  Class<?>[] value();
 }

--- a/src/test/java/jp/co/shimizutdev/phoneorderapi/support/ResetLogLevelExtension.java
+++ b/src/test/java/jp/co/shimizutdev/phoneorderapi/support/ResetLogLevelExtension.java
@@ -4,21 +4,21 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.springframework.boot.logging.LoggingSystem;
 
-/**
- * テストクラスで変更したログレベルをテスト後に戻す拡張
- */
+/** テストクラスで変更したログレベルをテスト後に戻す拡張 */
 public final class ResetLogLevelExtension implements AfterAllCallback {
 
-    @Override
-    public void afterAll(final ExtensionContext context) {
-        final ResetLogLevel resetLogLevel = context.getRequiredTestClass().getAnnotation(ResetLogLevel.class);
-        if (resetLogLevel == null) {
-            return;
-        }
-
-        final LoggingSystem loggingSystem = LoggingSystem.get(context.getRequiredTestClass().getClassLoader());
-        for (final Class<?> loggerClass : resetLogLevel.value()) {
-            loggingSystem.setLogLevel(loggerClass.getName(), null);
-        }
+  @Override
+  public void afterAll(final ExtensionContext context) {
+    final ResetLogLevel resetLogLevel =
+        context.getRequiredTestClass().getAnnotation(ResetLogLevel.class);
+    if (resetLogLevel == null) {
+      return;
     }
+
+    final LoggingSystem loggingSystem =
+        LoggingSystem.get(context.getRequiredTestClass().getClassLoader());
+    for (final Class<?> loggerClass : resetLogLevel.value()) {
+      loggingSystem.setLogLevel(loggerClass.getName(), null);
+    }
+  }
 }


### PR DESCRIPTION
## 概要

品質運用の自動化として、Java 整形、ビルド環境検証、依存ルール検査、CI 検証を追加しました。
あわせて OpenAPI 生成ソースの取り込み設定と開発ドキュメントを更新しました。

## Issue

close #138

## 対応内容

- `pom.xml` に Spotless を追加し、Java 整形ルールを自動化
- `pom.xml` に Maven Enforcer を追加し、Java / Maven バージョンと依存定義を検証
- `pom.xml` に `build-helper-maven-plugin` を追加し、OpenAPI 生成ソースを source root に登録
- ArchUnit を追加し、レイヤ依存ルールを `ArchitectureTest` で検証
- GitHub Actions の CI で `spotless:check test` を実行するよう更新
- `README.md` と `docs/09_development/development-flow.md` を更新し、品質チェック手順を明記

## 完了条件

実装担当者がチェック

- [x] `./mvnw spotless:check test` で整形・単体テスト・依存ルール検査が実行できる
- [x] GitHub Actions で同等の品質チェックが実行される
- [x] `ArchitectureTest` により主要なレイヤ依存ルールが検証される
- [x] OpenAPI 生成ソースが IDE / Maven で参照できる
- [x] 開発ドキュメントに品質チェック手順が反映されている

## レビュー観点

レビュー担当者がチェック

- [x] Spotless の整形方針が既存運用に対して妥当か
- [x] Maven Enforcer のルールが現行の開発環境と矛盾しないか
- [x] ArchUnit の依存ルールが過不足ないか
- [x] OpenAPI 生成ソースの source root 登録方針が妥当か
- [x] CI の `spotless:check test` がローカル運用と一致しているか

## 備考（任意）

Spotless 導入に伴い、既存の Java ソース・テストには機械整形差分が含まれます。
IntelliJ では Maven プロジェクトの再読込後に OpenAPI 生成ソースの unresolved symbol が解消されます。****