### PR TITLE
chore: .gitignoreを整理してローカル/生成物の扱いを明確化 (#156)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 HELP.md
+
+### Build outputs ###
 target/
 .mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
@@ -14,10 +16,11 @@ target/
 .sts4-cache
 
 ### IntelliJ IDEA ###
-.idea
+.idea/
 *.iws
 *.iml
 *.ipr
+# Shared IntelliJ settings live under config/intellij/
 
 ### NetBeans ###
 /nbproject/private/


### PR DESCRIPTION
## 概要

`.gitignore` を整理し、ビルド生成物と IntelliJ ローカル設定の扱いを明確化しました。

## Issue

close #156

## 対応内容・方針

- `target/` をビルド生成物として分かりやすくするため見出しを追加
- `.idea` を `.idea/` に統一し、IntelliJ のローカル設定ディレクトリ全体を無視する意図を明確化
- 共有 IntelliJ 設定は `config/intellij/` で管理する方針をコメントで明記

## 作業完了条件

確認した項目をチェック

- [x] `.gitignore` にローカル/生成物の扱い方針が反映されている
- [x] `.idea/` を Git 管理しない意図が明確になっている
- [x] 共有 IntelliJ 設定の置き場が `config/intellij/` であると分かる

## レビュー観点

レビュー時に見てほしいポイントを記載

- [x] `.gitignore` の整理方針がチーム運用に合っているか
- [x] `.idea/` を丸ごと無視する方針で問題ないか
- [x] `config/intellij/` を共有設定の置き場とする運用で十分か

## 補足

- 今回の変更対象は `.gitignore` のみです
- 現時点では `.idea/`、`target/`、`.env` は Git 追跡されていません
- 追跡解除のための `git rm --cached` は今回は不要でした