### PR TITLE
docs: README冒頭に公開Swagger導線を追加し、GitHub Pages配信を整備する (#159)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,42 @@
+name: Publish Swagger UI
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Prepare publish directory
+        run: |
+          mkdir -p _site/swagger
+          mkdir -p _site/openapi
+          cp site/swagger/index.html _site/swagger/index.html
+          cp specs/openapi/openapi.yaml _site/openapi/openapi.yaml
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
 `phone-order-api` は移動機注文を管理する Spring Boot ベースの REST API です。  
 注文一覧取得、注文取得、注文登録、注文キャンセルを提供します。
 
+## すぐ試せるもの
+
+- Swagger UI: `https://shimizut-dev.github.io/phone-order-api/swagger/`
+- Mock Server: `準備中`
+- OpenAPI 正本: [specs/openapi/openapi.yaml](specs/openapi/openapi.yaml)
+
 ---
 
 ## 概要

--- a/site/swagger/index.html
+++ b/site/swagger/index.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>phone-order-api Swagger UI</title>
+  <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist@5/swagger-ui.css">
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+<script>
+  window.onload = function () {
+    window.ui = SwaggerUIBundle({
+      url: "/phone-order-api/openapi/openapi.yaml",
+      dom_id: "#swagger-ui",
+      deepLinking: true,
+      presets: [
+        SwaggerUIBundle.presets.apis
+      ]
+    });
+  };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## 概要

README 冒頭に第三者がすぐ触れる入口を追加し、Swagger UI を GitHub Pages で公開できるようにしました。  
OpenAPI 正本（`specs/openapi/openapi.yaml`）を維持したまま、公開導線を明確化しています。

## Issue

close #159

## 対応内容

- README 冒頭に「すぐ試せるもの」セクションを追加
- Swagger UI 公開リンクを追加（`https://shimizut-dev.github.io/phone-order-api/swagger/`）
- Mock Server 状態を記載（準備中）
- OpenAPI 正本リンク（`specs/openapi/openapi.yaml`）を同セクションに配置
- GitHub Pages 配信用 workflow を追加（`.github/workflows/pages.yml`）
- Swagger UI 静的ページを `site/swagger/index.html` に追加
- workflow で `specs/openapi/openapi.yaml` を `_site/openapi/openapi.yaml` として配信するよう設定

## 完了条件

実装担当者がチェック

- [x] `main` push または手動実行で Pages workflow が成功する
- [x] `https://shimizut-dev.github.io/phone-order-api/swagger/` で Swagger UI が表示される
- [x] Swagger UI から `openapi/openapi.yaml` を読み込める
- [x] README 冒頭から Swagger UI と OpenAPI 正本へ遷移できる

## レビュー観点

レビュー担当者がチェック

- [x] `site/` 配下への配置方針（公開物と実装物の責務分離）が妥当か
- [x] Pages workflow の公開内容（`swagger/` と `openapi/`）が過不足ないか
- [x] README 冒頭の導線文言が初見ユーザー向けに分かりやすいか

## 備考（任意）

Mock Server の公開リンクは未対応（準備中）。公開時に README と OpenAPI `servers` のURL整合を別PRで対応予定です。