### PR TITLE
docs: Pages公開workflowをNode 24実行へ切り替える (#161)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,8 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## 概要

GitHub Pages 公開 workflow で表示されていた Node.js 20 非推奨警告に対応するため、`publish` ジョブを Node 24 実行に切り替えました。

## Issue

close #161

## 対応内容

- `.github/workflows/pages.yml` の `publish` ジョブに環境変数を追加
- `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` を設定

## 完了条件

実装担当者がチェック

- [x] `Publish Swagger UI` が成功する
- [x] 実行後の Annotations で Node.js 20 非推奨警告が表示されない

## レビュー観点

レビュー担当者がチェック

- [x] `publish` ジョブへの環境変数追加位置が適切か
- [x] Pages デプロイ動作に副作用がないか

## 備考（任意）

将来的に `actions/deploy-pages` / `actions/upload-pages-artifact` の新メジャーで Node 24 が標準化されたら、環境変数の要否を再評価する。