### PR TITLE
chore: JaCoCoレポートをCIに追加しREADMEに導線を整備 (#163)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,18 @@ jobs:
           java-version: '21'
           cache: maven
 
-      - name: Run tests
+      - name: Run tests and generate JaCoCo report
         env:
           TESTCONTAINERS_HOST_OVERRIDE: host.docker.internal
-        run: sh ./mvnw -B -Dmaven.repo.local="$HOME/.m2/repository" spotless:check test
+        run: sh ./mvnw -B -Dmaven.repo.local="$HOME/.m2/repository" spotless:check verify
+
+      - name: Upload JaCoCo report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-report
+          path: target/site/jacoco
+          if-no-files-found: error
 
       - name: Verify tracked files are unchanged after build
         run: |

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ docker compose -f docker/docker-compose.yml up -d
 テスト実行:
 
 ```bash
-./mvnw spotless:check test
+./mvnw spotless:check verify
 ```
 
 アプリ起動:
@@ -79,9 +79,15 @@ Windows の場合:
 
 ```powershell
 docker compose -f docker/docker-compose.yml up -d
-.\mvnw.cmd spotless:check test
+.\mvnw.cmd spotless:check verify
 .\mvnw.cmd spring-boot:run
 ```
+
+## JaCoCo レポート
+
+- ローカルで `./mvnw verify` 実行後、`target/site/jacoco/index.html` にカバレッジレポートを生成
+- CI では `jacoco-report` artifact として保存
+- GitHub Actions の該当 workflow run から `jacoco-report` をダウンロードして確認可能
 
 ---
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <spotbugs.version>4.9.4</spotbugs.version>
     <spotbugs-maven-plugin.version>4.9.4.1</spotbugs-maven-plugin.version>
     <spotless-maven-plugin.version>2.46.1</spotless-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
     <tomcat.version>10.1.54</tomcat.version>
     <openapi-generator.version>7.21.0</openapi-generator.version>
     <postgresql.version>42.7.11</postgresql.version>
@@ -303,9 +304,30 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
           <argLine>
-            -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
+            @{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar
           </argLine>
         </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
## 概要

JaCoCo を CI に組み込み、カバレッジレポートの生成と確認導線を整備しました。  
あわせて README のテスト実行コマンドを `verify` ベースに統一しました。

## Issue

close #163

## 対応方針

- `pom.xml` に `jacoco-maven-plugin` を追加
- `prepare-agent` と `report`（`verify` フェーズ）を設定
- `maven-surefire-plugin` の `argLine` を `@{argLine}` 形式に変更し JaCoCo と共存
- CI の Maven 実行を `spotless:check verify` に変更
- CI で `target/site/jacoco` を `jacoco-report` artifact としてアップロード
- README に JaCoCo レポートのローカル出力先と CI での確認方法を追記

## 完了条件

期待値チェックリスト

- [x] `verify` 実行で JaCoCo レポートが生成される
- [x] CI で `jacoco-report` artifact が保存される
- [x] README からレポート確認手順が分かる
- [x] 既存の差分検知ステップ（tracked files unchanged）が維持される

## レビュー観点

レビュー時に見てほしいポイント

- [x] `maven-surefire-plugin` の `argLine` 変更が既存テスト実行に影響しないか
- [x] CI の `verify` 化で実行時間・安定性に問題がないか
- [x] README の手順が実運用と一致しているか

## 補足（背景・目的）

テスト品質の「見える化」を目的に、JUnit レポート追加は行わず JaCoCo に絞って導入しています。