### PR TITLE
docs: READMEにContract-First Development（OpenAPI正本フロー）を追加する (#165)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@
 - Mock Server: `準備中`
 - OpenAPI 正本: [specs/openapi/openapi.yaml](specs/openapi/openapi.yaml)
 
+## Contract-First Development
+
+このリポジトリは `specs/openapi/openapi.yaml` を契約の正本として扱い、仕様変更から実装反映までを次の流れで進めます。
+
+1. OpenAPI 仕様を更新する
+2. `openapi-generator-maven-plugin` で生成コードを更新する
+3. テストを実行して整合性を確認する
+4. CI で契約と実装の差分・品質を検証する
+
+```text
+Edit OpenAPI spec
+        ↓
+Generate code (Maven plugin)
+        ↓
+Run tests locally
+        ↓
+Validate in CI
+```
+
 ---
 
 ## 概要


### PR DESCRIPTION
## 概要

READMEに、OpenAPIを正本とした契約駆動開発フローを明示する `Contract-First Development` セクションを追加しました。

## Issue

close #165

## 対応内容

- READMEの「すぐ試せるもの」直下に `Contract-First Development` セクションを追加
- `specs/openapi/openapi.yaml` を契約の正本として明記
- `OpenAPI更新 → 生成コード更新（openapi-generator-maven-plugin）→ テスト → CI` の4ステップを追記
- 上記フローのテキスト図を追加

## 完了条件

実装担当者がチェック

- [x] READMEに契約駆動フローのセクションが追加されている
- [x] OpenAPI正本の位置づけと開発フローが明確に記載されている
- [x] 変更対象がREADME内に限定されている

## レビュー観点

レビュー担当者がチェック

- [x] `Contract-First Development` セクションの配置がREADME全体の導線として自然か
- [x] 契約駆動フロー（OpenAPI更新→生成→テスト→CI）の説明が過不足ないか
- [x] 文言トーンが既存READMEと整合しているか

## 備考（任意）

なし