### PR TITLE
docs: READMEで品質管理とテスト/カバレッジ可視化を追加し、Mock Server表記を未提供へ更新 (#167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ## すぐ試せるもの
 
 - Swagger UI: `https://shimizut-dev.github.io/phone-order-api/swagger/`
-- Mock Server: `準備中`
+- Mock Server: `未提供`
 - OpenAPI 正本: [specs/openapi/openapi.yaml](specs/openapi/openapi.yaml)
 
 ## Contract-First Development
@@ -133,3 +133,34 @@ docker compose -f docker/docker-compose.yml up -d
 - [docker/docker-compose.yml](docker/docker-compose.yml)
 
 基本コマンドは `最短手順` を参照する
+
+---
+
+## 品質管理
+
+本プロジェクトでは、実装だけでなく品質管理も重視しています。
+
+- CI で `./mvnw spotless:check verify` を実行
+- JaCoCo によるカバレッジレポートを生成
+- OpenAPI 正本と生成コード、実装、テストの整合を確認
+
+## テスト / カバレッジ
+
+テストは単体テスト、統合テスト、アーキテクチャテストを対象としています。  
+カバレッジは JaCoCo により計測します。
+
+ローカルでの確認手順:
+
+```bash
+./mvnw clean verify
+```
+
+Windows の場合:
+
+```powershell
+.\mvnw.cmd clean verify
+```
+
+生成レポート:
+
+`target/site/jacoco/index.html`


### PR DESCRIPTION
## 概要

README に品質管理およびテスト/カバレッジの説明を追加し、Mock Server の表記を実態に合わせて更新しました。

## Issue

close #167

## 対応方針

- README の `Mock Server` 表記を `準備中` から `未提供` へ更新
- `品質管理` セクションを追加
- `テスト / カバレッジ` セクションを追加
- JaCoCo 利用、ローカル実行手順、レポート参照先を明記

## 完了条件

動作確認項目がチェック

- [x] README に品質管理セクションが追加されている
- [x] README にテスト / カバレッジセクションが追加されている
- [x] `./mvnw clean verify` と `.\mvnw.cmd clean verify` が記載されている
- [x] `target/site/jacoco/index.html` が記載されている
- [x] Mock Server 表記が `未提供` になっている

## レビュー観点

レビュー観点がチェック

- [x] README の記述が現行運用（営業用途）と一致しているか
- [x] 既存章との重複や矛盾がないか

## 補足（任意）

- 対象ファイル: `README.md`